### PR TITLE
Disable automatic Electron build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
 name: Build Electron Executable
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:  # Disabled: re-enable after Electron upgrade
+  # push:
+  #   branches:
+  #     - master
 
 jobs:
   build_on_mac:


### PR DESCRIPTION
## Summary

Temporarily disables the automatic Electron build that runs on every push to `master`. The workflow is still runnable manually via `workflow_dispatch`.

## Why

The Electron build is broken pending an upgrade. Disabling it removes the noise until that work is done.

## Re-enabling

Uncomment the `push` trigger in `.github/workflows/build.yml` and remove the `workflow_dispatch` line (or keep both).