### PR TITLE
fix(server): catch missing-projects.json crash in legacy proxy (#59)

### DIFF
--- a/src/server/controllers/migrationController.test.ts
+++ b/src/server/controllers/migrationController.test.ts
@@ -74,3 +74,24 @@ describe("migrationController with mock legacy data", () => {
     expect(response.status).toBe(404);
   });
 });
+
+// Regression test for issue #59: when projects.json is missing, the handler
+// previously threw synchronously inside an `async` function, which Express 4
+// does not catch — the resulting unhandled promise rejection took down the
+// whole server process.
+describe("migrationController without legacy data files", () => {
+  beforeAll(() => {
+    // Previous describe's afterAll already removed `stringsDir`, but be
+    // defensive in case test ordering changes.
+    if (fs.existsSync(stringsDir)) unlinkRecursive(stringsDir);
+  });
+
+  test("GET /api/admin/legacy/projects responds with 5xx instead of crashing when projects.json is missing", async () => {
+    const agent = await loggedInAgent();
+    const response = await agent
+      .get("/api/admin/legacy/projects")
+      .timeout({ deadline: 5000 });
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    expect(response.status).toBeLessThan(600);
+  }, 10000);
+});

--- a/src/server/controllers/migrationController.ts
+++ b/src/server/controllers/migrationController.ts
@@ -10,13 +10,19 @@ import {
   LegacyTStringWithMatches,
   LegacyTString
 } from "../../core/models/Legacy";
+import { handleErrors } from "../api/WebAPI";
 
 export default function migrationController(
   app: Express,
   storage: Persistence
 ) {
+  // Issue #59: legacyProjects() reads strings/projects.json synchronously and
+  // throws if it's missing. Without handleErrors, that throw becomes an
+  // unhandled promise rejection in this async handler and crashes the server.
   app.get("/api/admin/legacy/projects", async (req, res) => {
-    res.json(legacyProjects());
+    handleErrors(res, async () => {
+      res.json(legacyProjects());
+    });
   });
 
   type GetProjectResponse = {


### PR DESCRIPTION
## Summary

Fixes #59 — the entire Express server crashes when `GET /api/admin/legacy/projects` is requested and `strings/projects.json` is missing.

**Note on the issue description:** the bug report frames this as an HTTP-proxied upstream returning 504, but the actual implementation is file-based: `legacyProjects()` in `src/server/storage/legacyStorage.ts` uses `fs.readFileSync('strings/projects.json')`. When the file is missing, that throws synchronously inside the route handler's `async` callback. Express 4 doesn't intercept async-handler rejections, so the throw escapes as an unhandled rejection and crashes the process.

The codebase already has a `handleErrors` helper (`src/server/api/WebAPI.ts`) used by every other controller via `addGetHandler` / `addPostHandler`. This change wraps the one outlier with it.

Built with strict Red-Green-Refactor TDD:
1. **Red** — new test asserts that with `strings/` absent, `GET /api/admin/legacy/projects` responds with 5xx (it previously hung, leaving an unhandled rejection).
2. **Green** — wrap the handler with `handleErrors`.

## Stacked on

This PR is stacked on top of #74 (the fix for issue #64). Base branch is `fix/issue-64-clear-error-on-navigation`. Once #74 merges, retarget to `feature/node-24-migration` (or merge in order).

## Test plan

- [x] New regression test passes (`migrationController without legacy data files`)
- [x] Existing 4 migrationController tests still pass
- [x] Full Jest run: 957 tests passing (was 956 before this change; the additional pass is the new test). The 35 \"test suite failed to run\" entries are pre-existing failures from stale compiled output in `dist/frontend/**` and are not introduced by this change.
- [x] `tsc -b src/frontend src/desktop src/server` clean
- [ ] Manual: stop the legacy upstream / remove `strings/projects.json`, hit `/migrate`, confirm the server returns an error response and keeps serving other routes

## Related cleanup not done here

`src/server/controllers/testController.ts` has three other unwrapped `async` handlers (`reset-storage`, `persist-storage`, `close-storage`) with the same latent risk, but they're test-only and out of scope for this critical fix. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)