### PR TITLE
fix(csp): allow styled-components runtime styles via per-request nonce

### DIFF
--- a/src/frontend/webApp.tsx
+++ b/src/frontend/webApp.tsx
@@ -8,6 +8,18 @@ import store from "./common/state/appState";
 import RequestContext from "./common/api/RequestContext";
 import { webGet, webPost } from "../core/api/WebAPIClient";
 
+// Wire the per-request CSP nonce (injected by the server as a <meta> tag in the
+// document head) into webpack's runtime nonce, so styled-components stamps it on
+// the <style> tags it injects at runtime. Without this, the production CSP
+// (style-src with a per-request nonce and no 'unsafe-inline') blocks those styles
+// and styled-components throws "CSSStyleSheet could not be found on
+// HTMLStyleElement". Must run before the first render below.
+declare let __webpack_nonce__: string;
+const cspNonce = document.querySelector('meta[name="csp-nonce"]')?.getAttribute("content");
+if (cspNonce) {
+  __webpack_nonce__ = cspNonce;
+}
+
 function WebApp() {
   return (
     <Provider store={store}>

--- a/src/server/serverApp.test.ts
+++ b/src/server/serverApp.test.ts
@@ -50,6 +50,19 @@ describe("HTTP security headers", () => {
     const styleSrcValue = styleSrcMatch ? styleSrcMatch[1] : "";
     expect(styleSrcValue).not.toContain("'unsafe-inline'");
   });
+
+  test("Content-Security-Policy styleSrc carries a per-request nonce", async () => {
+    // styled-components injects runtime <style> tags; without a style-src nonce
+    // (and with no 'unsafe-inline') the production SPA throws
+    // "CSSStyleSheet could not be found on HTMLStyleElement". Must hit a 200 route
+    // because Express's finalhandler replaces the CSP with "default-src 'none'"
+    // on 404/error responses, masking helmet's policy.
+    const app = serverApp({ silent: true });
+    const response = await request(app).get("/api/languages");
+    const csp = (response.header["content-security-policy"] ?? "") as string;
+    const styleSrc = csp.match(/style-src\s+([^;]*)/i)?.[1] ?? "";
+    expect(styleSrc).toMatch(/'nonce-[A-Za-z0-9+/=]+'/);
+  });
 });
 
 test("serverApp can be called with no arguments (default opts)", () => {
@@ -181,6 +194,35 @@ describe("serverApp production branch", () => {
       // With the dist/frontend/index.html in place this MUST be 200
       expect(response.status).toBe(200);
       expect(response.text).toContain("<html>");
+    });
+  });
+
+  test("wildcard route injects the per-request CSP nonce into the served HTML", async () => {
+    await withProductionServerApp(async (app) => {
+      const response = await request(app).get("/any/frontend/path");
+      expect(response.status).toBe(200);
+      const csp = (response.header["content-security-policy"] ?? "") as string;
+      const headerNonce = csp.match(/'nonce-([A-Za-z0-9+/=]+)'/)?.[1];
+      expect(headerNonce).toBeTruthy();
+      // The HTML the SPA loads must carry the SAME nonce the CSP advertises so
+      // webApp.tsx can wire it into styled-components' __webpack_nonce__.
+      expect(response.text).toContain(`<meta name="csp-nonce" content="${headerNonce}">`);
+    });
+  });
+
+  test("each request gets a fresh, unique CSP nonce", async () => {
+    await withProductionServerApp(async (app) => {
+      const nonceOf = async () => {
+        // 200 catch-all so finalhandler doesn't clobber helmet's CSP header
+        const r = await request(app).get("/any/frontend/path");
+        const csp = (r.header["content-security-policy"] ?? "") as string;
+        return csp.match(/'nonce-([A-Za-z0-9+/=]+)'/)?.[1];
+      };
+      const first = await nonceOf();
+      const second = await nonceOf();
+      expect(first).toBeTruthy();
+      expect(second).toBeTruthy();
+      expect(first).not.toBe(second);
     });
   });
 });

--- a/src/server/serverApp.ts
+++ b/src/server/serverApp.ts
@@ -1,5 +1,7 @@
 import express from "express";
 import helmet from "helmet";
+import crypto from "crypto";
+import fs from "fs";
 import bodyParser from "body-parser";
 import { toNodeHandler } from "better-auth/node";
 import languagesController from "./controllers/languagesController";
@@ -33,6 +35,17 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
 
   app.set("trust proxy", 1);
 
+  // Per-request CSP nonce. styled-components injects its CSS as runtime <style>
+  // tags, which the Content-Security-Policy below would otherwise block (we keep
+  // style-src free of 'unsafe-inline'). Each request gets a fresh nonce that is
+  // advertised in the style-src directive (see below) and stamped onto the served
+  // HTML (see the production catch-all) so the SPA can hand it to styled-components.
+  // Must run before helmet so the directive function can read res.locals.cspNonce.
+  app.use((req, res, next) => {
+    res.locals.cspNonce = crypto.randomBytes(16).toString("base64");
+    next();
+  });
+
   // HTTP security headers — helmet must be registered before any route handlers.
   // Cast required: helmet v8 types use Node IncomingMessage/ServerResponse while
   // Express app.use() expects its own RequestHandler type.
@@ -49,7 +62,12 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
         directives: {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'"],
-          styleSrc: ["'self'"],
+          // Allow styled-components' runtime <style> tags via a per-request
+          // nonce instead of the blanket 'unsafe-inline'.
+          styleSrc: [
+            "'self'",
+            (_req, res) => `'nonce-${(res as express.Response).locals.cspNonce}'`,
+          ],
           imgSrc: ["'self'", "data:", "blob:"],
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],
@@ -65,7 +83,9 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
   app.use("/api/admin", requireAdmin);
 
   if (PRODUCTION) {
-    app.use(express.static("dist/frontend"));
+    // index:false so "/" falls through to the nonce-injecting catch-all below
+    // rather than being served as an un-nonced static index.html.
+    app.use(express.static("dist/frontend", { index: false }));
   }
 
   app.use("/webified", express.static(docStorage.webifyPath()));
@@ -95,9 +115,28 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
   }
 
   if (PRODUCTION) {
-    // Handle client-side routes
+    // Serve the SPA shell for client-side routes, injecting the per-request CSP
+    // nonce into the document head as a <meta> tag. webApp.tsx reads it and wires
+    // it into styled-components (via __webpack_nonce__) so its runtime <style>
+    // tags satisfy the style-src nonce. The built HTML is read once and cached;
+    // only the nonce varies per request.
+    const indexHtmlPath = `${process.cwd()}/dist/frontend/index.html`;
+    let indexHtmlTemplate: string | null = null;
     app.get("*", (req, res) => {
-      res.sendFile(`${process.cwd()}/dist/frontend/index.html`);
+      try {
+        if (indexHtmlTemplate === null) {
+          indexHtmlTemplate = fs.readFileSync(indexHtmlPath, "utf8");
+        }
+        const nonce = res.locals.cspNonce as string;
+        // base64 contains no HTML metacharacters, so it is safe to interpolate.
+        const metaTag = `<meta name="csp-nonce" content="${nonce}">`;
+        const html = indexHtmlTemplate.includes("<head>")
+          ? indexHtmlTemplate.replace("<head>", `<head>${metaTag}`)
+          : `${metaTag}${indexHtmlTemplate}`;
+        res.type("html").send(html);
+      } catch {
+        res.status(500).send("Internal Server Error");
+      }
     });
   }
 


### PR DESCRIPTION
## Problem

Production white-screens with `TypeError: CSSStyleSheet could not be found on HTMLStyleElement`.

**Root cause:** PR #94 (better-auth migration) added a CSP via helmet with `style-src 'self'` (no `'unsafe-inline'`, no nonce). styled-components v5 injects its CSS as runtime inline `<style>` tags and, in production, uses CSSOM `insertRule()`, which requires the browser to grant the tag a `CSSStyleSheet`. The CSP blocks the inline style, so the tag never gets a sheet and styled-components throws on the first render — taking down the whole web app.

**Why production-only:** dev is served by webpack-dev-server (no helmet/CSP), and styled-components uses text-node injection outside production — so neither dev nor the unit suite ever exercised "this CSP + the real app rendering in a browser." (The earlier commit that dropped `'unsafe-inline'` assumed `insertRule()` didn't need it, but `insertRule` doesn't bypass CSP: the inline `<style>` element itself is governed by `style-src`.)

## Fix

Per-request nonce, keeping the strict policy (`script-src` stays `'self'`):

- **`serverApp.ts`** — generate a per-request nonce (`res.locals.cspNonce`); advertise it in `style-src` via a helmet directive function; serve static with `{ index: false }` so `/` routes through the catch-all; the catch-all injects `<meta name="csp-nonce">` into the served HTML (cached read of `index.html`, fresh nonce per request).
- **`webApp.tsx`** — read the meta nonce into webpack's `__webpack_nonce__` before first render, so styled-components stamps the nonce on the `<style>` tags it creates.

## Tests (falsifiable)

- `style-src` carries a per-request nonce
- the served HTML carries the **same** nonce the CSP advertises
- the nonce is unique per request

Verified red→green: all three fail at the nonce assertions when the fix is reverted, and pass with it. Full `serverApp.test.ts`: **13/13 passing**.

## Follow-up (not in this PR)

This slipped because no test runs the **production server + production build in a real browser**. Recommend a prod-mode Cypress/Playwright smoke test asserting no CSP violations and that styles render — that closes the whole class of bug, not just this instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
