### PR TITLE
fix(auth): normalize doubled X-Forwarded-Proto and key rate-limit on real client IP

### DIFF
--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -62,6 +62,15 @@ export function getAuth(): ReturnType<typeof betterAuth<any>> {
       // Left undefined elsewhere → better-auth's env default (enforced in
       // production, skipped in test/dev so cross-origin dev login still works).
       disableOriginCheck: process.env.BETTER_AUTH_ENFORCE_ORIGIN === "1" ? false : undefined,
+      // Key rate-limiting on the real, non-spoofable client IP. better-auth
+      // derives the client IP itself (it ignores Express req.ip), defaulting to
+      // the leftmost x-forwarded-for token — which Cloudflare PREPENDS any
+      // client-supplied value to, so it's spoofable. cf-connecting-ip is
+      // Cloudflare's authoritative client IP; the first header yielding a valid
+      // IP wins. Cloudflare ON → cf-connecting-ip; Cloudflare OFF (or supertest,
+      // where neither header is present) → falls back to x-forwarded-for / the
+      // socket IP. Independent of Express's `trust proxy`.
+      ipAddress: { ipAddressHeaders: ["cf-connecting-ip", "x-forwarded-for"] },
     },
     emailAndPassword: {
       enabled: true,

--- a/src/server/middle/normalizeForwardedProto.test.ts
+++ b/src/server/middle/normalizeForwardedProto.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="jest" />
+
+import { Request, Response, NextFunction } from "express";
+import normalizeForwardedProto from "./normalizeForwardedProto";
+
+// Build a minimal mock req/res/next. We only exercise req.headers and next().
+function mockCtx(headers: Record<string, string | string[] | undefined>): {
+  req: Request;
+  res: Response;
+  next: jest.Mock<void, []> & NextFunction;
+} {
+  const req = { headers } as unknown as Request;
+  const res = {} as Response;
+  const next = jest.fn() as jest.Mock<void, []> & NextFunction;
+  return { req, res, next };
+}
+
+describe("normalizeForwardedProto", () => {
+  test('doubled "https, https" collapses to "https"', () => {
+    const { req, res, next } = mockCtx({ "x-forwarded-proto": "https, https" });
+    normalizeForwardedProto(req, res, next);
+    expect(req.headers["x-forwarded-proto"]).toBe("https");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("single value is left unchanged", () => {
+    const { req, res, next } = mockCtx({ "x-forwarded-proto": "https" });
+    normalizeForwardedProto(req, res, next);
+    expect(req.headers["x-forwarded-proto"]).toBe("https");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('array form ["https", "https"] collapses to "https"', () => {
+    const { req, res, next } = mockCtx({ "x-forwarded-proto": ["https", "https"] });
+    normalizeForwardedProto(req, res, next);
+    expect(req.headers["x-forwarded-proto"]).toBe("https");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("missing header is left untouched (no key added)", () => {
+    const { req, res, next } = mockCtx({ host: "example.com" });
+    normalizeForwardedProto(req, res, next);
+    expect("x-forwarded-proto" in req.headers).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    const { req, res, next } = mockCtx({ "x-forwarded-proto": "  https ,  http " });
+    normalizeForwardedProto(req, res, next);
+    expect(req.headers["x-forwarded-proto"]).toBe("https");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls next() exactly once", () => {
+    const { req, res, next } = mockCtx({ "x-forwarded-proto": "https, https" });
+    normalizeForwardedProto(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/middle/normalizeForwardedProto.ts
+++ b/src/server/middle/normalizeForwardedProto.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Express middleware: collapse a doubled `X-Forwarded-Proto` header to its
+ * first comma-separated token.
+ *
+ * Behind two appending proxies (e.g. Cloudflare → Phusion Passenger) each hop
+ * *appends* its scheme, so the Node app receives `x-forwarded-proto: "https, https"`.
+ * Express collapses this to the first token for its own `req.protocol`, but
+ * better-auth's `toNodeHandler` rebuilds a Web `Request` from the *raw*
+ * `req.headers` (via `fromNodeHeaders`), so it sees the malformed value and
+ * builds a base URL like `"https, https://host"`. We normalize the raw header at
+ * the trust boundary — before the auth handler runs — so every downstream
+ * consumer sees a single, clean scheme.
+ *
+ * Keeps "first token" semantics to match Express's own `req.protocol`: the
+ * leftmost value is the original client→proxy protocol.
+ *
+ * No-op when the header is absent (the key is never added). Handles the
+ * `string | string[]` shape Node exposes for headers. Mutating `req.headers` is
+ * what propagates the fix to better-auth's `fromNodeHeaders`.
+ *
+ * @param req - Express Request (req.headers mutated in place)
+ * @param _res - Express Response (unused)
+ * @param next - Express NextFunction
+ */
+export default function normalizeForwardedProto(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  const raw = req.headers["x-forwarded-proto"];
+  if (raw === undefined) {
+    // Header absent — leave req.headers untouched (don't introduce the key).
+    next();
+    return;
+  }
+  // Node exposes a repeated header as string[]; otherwise it's a single string.
+  // Either way the leftmost comma-separated token is the original client→proxy
+  // protocol; trim surrounding whitespace.
+  const value = Array.isArray(raw) ? (raw[0] ?? "") : raw;
+  req.headers["x-forwarded-proto"] = value.split(",")[0].trim();
+  next();
+}

--- a/src/server/serverApp.test.ts
+++ b/src/server/serverApp.test.ts
@@ -63,6 +63,19 @@ describe("HTTP security headers", () => {
     const styleSrc = csp.match(/style-src\s+([^;]*)/i)?.[1] ?? "";
     expect(styleSrc).toMatch(/'nonce-[A-Za-z0-9+/=]+'/);
   });
+
+  test('a doubled X-Forwarded-Proto ("https, https") is handled without breaking the response', async () => {
+    // Boundary smoke check: the normalizeForwardedProto middleware collapses the
+    // doubled header (Cloudflare + Passenger each append a scheme) before any
+    // downstream handler. The request must still succeed with normal security headers.
+    const app = serverApp({ silent: true });
+    const response = await request(app)
+      .get("/api/languages")
+      .set("X-Forwarded-Proto", "https, https");
+    expect(response.status).toBe(200);
+    expect(response.header["x-content-type-options"]).toBe("nosniff");
+    expect(response.header["content-security-policy"]).toBeDefined();
+  });
 });
 
 test("serverApp can be called with no arguments (default opts)", () => {

--- a/src/server/serverApp.ts
+++ b/src/server/serverApp.ts
@@ -7,6 +7,7 @@ import { toNodeHandler } from "better-auth/node";
 import languagesController from "./controllers/languagesController";
 import lessonsController from "./controllers/lessonsController";
 import { requireAdmin } from "./middle/requireUser";
+import normalizeForwardedProto from "./middle/normalizeForwardedProto";
 import tStringsController from "./controllers/tStringsController";
 import testController from "./controllers/testController";
 import documentsController from "./controllers/documentsController";
@@ -33,7 +34,22 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
     console.log(`[serverApp] NODE_ENV=${process.env.NODE_ENV} storage=${cls}`);
   }
 
+  // Trust one proxy hop for req.protocol/req.ip. NOTE: under Cloudflare +
+  // Passenger there are TWO hops, so req.ip currently resolves to a Cloudflare
+  // edge IP (172.64.0.0/13). Harmless today — no app code reads req.ip — but
+  // before the 002 invitation limiter merges (it keys on req.ip), either set
+  // `trust proxy = 2` AND restrict the origin to Cloudflare's published IP
+  // ranges (otherwise req.ip becomes spoofable), or have that limiter read
+  // `cf-connecting-ip` directly. Left at 1 for now.
   app.set("trust proxy", 1);
+
+  // Normalize a doubled X-Forwarded-Proto at the trust boundary. Cloudflare and
+  // Passenger each APPEND their scheme, so the app sees "https, https"; left
+  // unchanged, better-auth's toNodeHandler (which reads the RAW req.headers)
+  // builds a malformed base URL like "https, https://host". This must run first
+  // — before the CSP-nonce middleware and crucially before the terminal auth
+  // handler below — so the normalized header reaches better-auth's fromNodeHeaders.
+  app.use(normalizeForwardedProto);
 
   // Per-request CSP nonce. styled-components injects its CSS as runtime <style>
   // tags, which the Content-Security-Policy below would otherwise block (we keep


### PR DESCRIPTION
## Context

A tester running the app in production mode on a staging server behind **Cloudflare + Phusion Passenger** found that auth breaks because **both proxies append to `X-Forwarded-Proto`**, so the Node app receives `x-forwarded-proto: "https, https"`. better-auth then builds a malformed base URL like `"https, https://luke-staging.silcam.org"` — even though `BETTER_AUTH_URL` is set via `passenger_env_var`.

Confirmed on staging by logging raw headers on `/api/auth/*`:

- `x-forwarded-proto: "https, https"` — confirmed.
- `x-forwarded-for: "63.155.24.47, 172.68.175.39"` — confirmed (real client, then a Cloudflare edge IP in `172.64.0.0/13`).

**Root cause:** two proxies each *append* their value. Express collapses this to the first token for its own `req.protocol`, but better-auth's `toNodeHandler` rebuilds a Web `Request` from the **raw** `req.headers` (`fromNodeHeaders`), so it sees the malformed value. That is why setting `BETTER_AUTH_URL` doesn't fully save it, and why normalizing the raw header *before* the auth handler is what fixes it — with Cloudflare on or off.

The fix lives in-app rather than in nginx/Passenger because the tester already tried (and failed) to make the proxy overwrite the header; an in-app fix is portable (works Cloudflare on/off) and version-independent.

## Changes

1. **Normalize `X-Forwarded-Proto` at the app boundary (primary fix).** New `src/server/middle/normalizeForwardedProto.ts` collapses the header to its first comma-separated token (matching Express's own `req.protocol` semantics). Registered as the *first* `app.use` in `serverApp.ts` — before the CSP-nonce middleware and crucially before the terminal `/api/auth/*` handler — so the normalized header reaches better-auth's `fromNodeHeaders`. No-op when the header is absent or already single; handles `string | string[]`.

2. **Key rate-limiting on the real, non-spoofable client IP.** `auth.ts` `advanced` block now sets `ipAddress.ipAddressHeaders: ["cf-connecting-ip", "x-forwarded-for"]`. better-auth derives the client IP itself (it ignores Express `req.ip`) and defaults to the leftmost `x-forwarded-for` token — which Cloudflare *prepends* client-supplied values to, so it's spoofable. `cf-connecting-ip` is authoritative. Cloudflare OFF / supertest → falls back to `x-forwarded-for`. Independent of `trust proxy`.

3. **Document the `trust proxy` / two-hop implication** (comment only, no behavior change). Under Cloudflare + Passenger there are two hops, so `req.ip` resolves to a Cloudflare edge IP. Harmless today (no app code reads `req.ip`), but the future 002 invitation limiter keys on `req.ip`; the comment records the required follow-up. `trust proxy` left at `1`.

## Tests

- **New** `normalizeForwardedProto.test.ts` (unit): `"https, https"` → `"https"`; single value unchanged; array form → `"https"`; missing header untouched (no key added); whitespace trimmed; `next()` called once.
- **Added** a boundary smoke case to `serverApp.test.ts`: a doubled `X-Forwarded-Proto` to `/api/languages` still returns `200` with normal security headers.

## Verification

- `yarn typecheck` → clean (also runs in pre-commit).
- `normalizeForwardedProto.test.ts` + `serverApp.test.ts` → 20/20 pass.
- `yarn test:integration` → 15/15 pass, including the `>10 attempts → 429` rate-limit test (confirms the `ipAddressHeaders` change is safe — `cf-connecting-ip` is absent under supertest, so it falls back to the test localhost IP).

Remaining steps are operational (build, deploy to staging, restart Passenger, sign-in checks with Cloudflare on/off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
