### PR TITLE
refactor(invitation): derive status from timestamps, drop the status column (#115)

### DIFF
--- a/cypress/integration/invitation-system.spec.js
+++ b/cypress/integration/invitation-system.spec.js
@@ -83,21 +83,28 @@ describe("US1 — Admin issues an invitation", () => {
     cy.contains("An account already exists for this email address.").should("exist");
   });
 
-  it("rejects a second invitation for an email with an active pending invitation (FR-005)", () => {
+  it("refreshes the invite when re-inviting an email with an open invitation (FR-005, #115)", () => {
     const email = uniqueEmail("us1-dupe");
 
-    // Create first invitation via API
-    apiCreateInvitation(email, "standard");
+    // Create first invitation via API and remember its token
+    apiCreateInvitation(email, "standard").then((first) => {
+      const firstToken = first.link.split("/invitation/")[1];
 
-    // Now try to create a second one via the UI
-    cy.visit("/admin/invitations/new");
-    cy.inLabel("Recipient Email").type(email);
+      // Now re-invite the same email via the UI — it refreshes, not conflicts
+      cy.visit("/admin/invitations/new");
+      cy.inLabel("Recipient Email").type(email);
 
-    cy.intercept("POST", "/api/admin/invitations").as("createInvitation");
-    cy.contains("button", "Create Invitation").click();
-    cy.wait("@createInvitation").its("response.statusCode").should("eq", 409);
+      cy.intercept("POST", "/api/admin/invitations").as("createInvitation");
+      cy.contains("button", "Create Invitation").click();
+      cy.wait("@createInvitation").its("response.statusCode").should("eq", 201);
 
-    cy.contains("An active invitation already exists for this email address.").should("exist");
+      // The refreshed link is shown (and differs from the original)
+      cy.contains("button", "Copy Link").should("exist");
+      cy.get("p")
+        .invoke("text")
+        .should("include", "/invitation/")
+        .and("not.include", firstToken);
+    });
   });
 });
 

--- a/migrations/1781767466147-AddInvitationRetractedAtDropStatus.js
+++ b/migrations/1781767466147-AddInvitationRetractedAtDropStatus.js
@@ -1,0 +1,82 @@
+"use strict";
+const { makeDbConnect } = require("./_helpers");
+
+const dbConnect = makeDbConnect();
+
+// Derived-status refactor (#115): the denormalized `status` column is the only
+// reason the two lazy-expire UPDATEs exist. Replace it with a `retractedAt`
+// timestamp so status can be DERIVED from (retractedAt, acceptedAt, expiresAt)
+// in every SELECT — a single source of truth, no drift.
+//
+// Derivation rule (kept in sync with STATUS_CASE_SQL in invitationStore.ts):
+//   retractedAt IS NOT NULL -> 'retracted'
+//   acceptedAt  IS NOT NULL -> 'accepted'
+//   expiresAt   <= now()    -> 'expired'
+//   else                    -> 'pending'
+
+module.exports.up = async () => {
+  await dbConnect(async (sql) => {
+    console.log("Adding invitation.retractedAt, dropping invitation.status...");
+
+    // 1. Add the new nullable marker column.
+    await sql`ALTER TABLE "invitation" ADD COLUMN "retractedAt" timestamptz`;
+
+    // 2. Backfill: only 'retracted' rows need a marker. 'accepted' already has
+    //    acceptedAt; 'expired' derives from expiresAt. createdAt is a safe
+    //    non-null stand-in for the retraction time of legacy rows.
+    await sql`
+      UPDATE "invitation" SET "retractedAt" = "createdAt" WHERE "status" = 'retracted'
+    `;
+
+    // 3. Drop the old status-based partial unique index.
+    await sql`DROP INDEX IF EXISTS "uq_invitation_one_pending_email"`;
+
+    // 4. Create the new partial unique index (FR-005: one OPEN invite per email).
+    //    "Open" = not accepted and not retracted (includes past-due rows, which
+    //    re-invite refreshes in place via UPSERT).
+    await sql`
+      CREATE UNIQUE INDEX "uq_invitation_one_open_email"
+        ON "invitation"(LOWER("email"))
+        WHERE "acceptedAt" IS NULL AND "retractedAt" IS NULL
+    `;
+
+    // 5. Drop the denormalized status column.
+    await sql`ALTER TABLE "invitation" DROP COLUMN "status"`;
+
+    console.log("Done.");
+  });
+};
+
+module.exports.down = async () => {
+  await dbConnect(async (sql) => {
+    console.log("Restoring invitation.status, dropping invitation.retractedAt...");
+
+    // 1. Re-add the status column with the original default.
+    await sql`ALTER TABLE "invitation" ADD COLUMN "status" text NOT NULL DEFAULT 'pending'`;
+
+    // 2. Backfill status from the timestamps via the same derivation rule.
+    await sql`
+      UPDATE "invitation" SET "status" = CASE
+        WHEN "retractedAt" IS NOT NULL THEN 'retracted'
+        WHEN "acceptedAt"  IS NOT NULL THEN 'accepted'
+        WHEN "expiresAt"   <= now()    THEN 'expired'
+        ELSE 'pending'
+      END
+    `;
+
+    // 3. Drop the open-email index.
+    await sql`DROP INDEX IF EXISTS "uq_invitation_one_open_email"`;
+
+    // 4. Recreate the original status-based partial unique index.
+    await sql`
+      CREATE UNIQUE INDEX "uq_invitation_one_pending_email"
+        ON "invitation"(LOWER("email"))
+        WHERE "status" = 'pending'
+    `;
+
+    // 5. Drop the retractedAt column.
+    await sql`ALTER TABLE "invitation" DROP COLUMN "retractedAt"`;
+
+    console.log("Done.");
+  });
+};

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -95,7 +95,6 @@ const en = {
   Invitation_error_malformed_email: "Please enter a valid email address.",
   Invitation_error_invalid_role: "Please select a valid role.",
   Invitation_error_account_exists: "An account already exists for this email address.",
-  Invitation_error_active_pending: "An active invitation already exists for this email address.",
   Invitation_create_heading_ready: "Invitation ready",
   Invitation_share_instructions:
     "Share this single-use link with the person you invited. It can be used only once.",

--- a/src/frontend/web/invitations/CreateInvitation.test.tsx
+++ b/src/frontend/web/invitations/CreateInvitation.test.tsx
@@ -246,36 +246,6 @@ describe("CreateInvitation", () => {
       });
     });
 
-    it("shows a distinct Alert when server returns active_pending (409)", async () => {
-      createInvitation.mockReturnValue(
-        jest.fn().mockResolvedValue({
-          payload: { code: "active_pending" },
-          error: { message: "rejected" },
-        })
-      );
-
-      const { container, getByText } = renderWithProviders(
-        <CreateInvitation />,
-        defaultInitialState
-      );
-
-      await act(async () => {
-        fireEvent.click(createButton());
-      });
-
-      await waitFor(() => {
-        const alerts = container.querySelectorAll("[role='alert'], .alert");
-        const found = Array.from(alerts).some((el) =>
-          /active invitation already exists/i.test(el.textContent || "")
-        );
-        if (!found) {
-          expect(getByText(/active invitation already exists/i)).toBeTruthy();
-        } else {
-          expect(found).toBe(true);
-        }
-      });
-    });
-
     it("shows the friendly email message when server returns malformed_email (400)", async () => {
       createInvitation.mockReturnValue(
         jest.fn().mockResolvedValue({
@@ -336,7 +306,7 @@ describe("CreateInvitation", () => {
       });
     });
 
-    it("the account-exists and active-pending alerts show different messages", async () => {
+    it("the account-exists and malformed-email alerts show different messages", async () => {
       // First render: account_exists
       createInvitation.mockReturnValue(
         jest.fn().mockResolvedValue({
@@ -365,10 +335,10 @@ describe("CreateInvitation", () => {
         expect(msg1.length).toBeGreaterThan(0);
       });
 
-      // Second render: active_pending — unmount first to avoid cross-render confusion
+      // Second render: malformed_email — a distinct error variant
       createInvitation.mockReturnValue(
         jest.fn().mockResolvedValue({
-          payload: { code: "active_pending" },
+          payload: { code: "malformed_email" },
           error: { message: "rejected" },
         })
       );
@@ -387,7 +357,7 @@ describe("CreateInvitation", () => {
       let msg2 = "";
       await waitFor(() => {
         try {
-          msg2 = getByText2(/active invitation already exists/i).textContent || "";
+          msg2 = getByText2(/please enter a valid email address/i).textContent || "";
         } catch {
           /* tolerate */
         }

--- a/src/frontend/web/invitations/CreateInvitation.tsx
+++ b/src/frontend/web/invitations/CreateInvitation.tsx
@@ -114,8 +114,6 @@ export default function CreateInvitation() {
     switch (submitError.code) {
       case "account_exists":
         return t("Invitation_error_account_exists");
-      case "active_pending":
-        return t("Invitation_error_active_pending");
       case "malformed_email":
         return t("Invitation_error_malformed_email");
       case "invalid_role":

--- a/src/frontend/web/invitations/invitationThunks.test.ts
+++ b/src/frontend/web/invitations/invitationThunks.test.ts
@@ -99,20 +99,17 @@ describe("invitationThunks", () => {
       expect(rejectedCall![0].payload).toMatchObject({ code: "account_exists" });
     });
 
-    it("on 409 active-pending, rejects with { code: 'active_pending' }", async () => {
+    it("on an unknown 409 variant, rejects with { code: 'validation_error' }", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 409,
-        json: async () => ({
-          error: "An active pending invitation already exists for pending@example.com",
-          code: "PENDING_INVITE_EXISTS",
-        }),
+        json: async () => ({ error: "Some other conflict", code: "SOME_OTHER_CONFLICT" }),
       });
 
       const dispatch = jest.fn();
       const getState = jest.fn();
 
-      await createInvitation({ email: "pending@example.com", role: "standard" })(
+      await createInvitation({ email: "user@example.com", role: "standard" })(
         dispatch,
         getState,
         undefined
@@ -122,7 +119,7 @@ describe("invitationThunks", () => {
         ([action]) => action.type === "invitations/createInvitation/rejected"
       );
       expect(rejectedCall).toBeTruthy();
-      expect(rejectedCall![0].payload).toMatchObject({ code: "active_pending" });
+      expect(rejectedCall![0].payload).toMatchObject({ code: "validation_error" });
     });
 
     it("on 400, rejects with { code: 'validation_error' }", async () => {

--- a/src/frontend/web/invitations/invitationThunks.ts
+++ b/src/frontend/web/invitations/invitationThunks.ts
@@ -6,7 +6,7 @@
  *
  * POST /api/admin/invitations → { id, email, role, status, link, expiresAt }
  *
- * Error shape: { code: 'account_exists' | 'active_pending' | 'malformed_email' | 'invalid_role' | 'validation_error' | 'network_error', message: string }
+ * Error shape: { code: 'account_exists' | 'malformed_email' | 'invalid_role' | 'validation_error' | 'network_error', message: string }
  */
 
 import { createAsyncThunk } from "@reduxjs/toolkit";
@@ -17,7 +17,6 @@ export type { InvitationResult };
 export interface InvitationError {
   code:
     | "account_exists"
-    | "active_pending"
     | "malformed_email"
     | "invalid_role"
     | "validation_error"
@@ -58,10 +57,8 @@ export const createInvitation = createAsyncThunk<
     if (body.code === "ACCOUNT_EXISTS") {
       return rejectWithValue({ code: "account_exists", message: errorText });
     }
-    if (body.code === "PENDING_INVITE_EXISTS") {
-      return rejectWithValue({ code: "active_pending", message: errorText });
-    }
-    // Unknown 409 variant — treat as generic
+    // Unknown 409 variant — treat as generic. (Re-inviting an open email no
+    // longer 409s: it refreshes the invite and returns 201; see #115.)
     return rejectWithValue({ code: "validation_error", message: errorText });
   }
 

--- a/src/server/auth/invitation.integration.test.ts
+++ b/src/server/auth/invitation.integration.test.ts
@@ -652,18 +652,26 @@ test("FR-004: duplicate account email → 409", async () => {
   expect(res.body.error).toBeDefined();
 });
 
-test("FR-005: second invitation for same email while first is pending → 409", async () => {
+test("FR-005: re-inviting an open email refreshes it → 201, new link, old link dead (#115)", async () => {
   const sharedEmail = "integration-dup-pending@example.com";
 
   // First invitation succeeds
-  await adminCreateInvitation(sharedEmail);
+  const first = await adminCreateInvitation(sharedEmail);
+  const firstToken = extractToken(first.link);
 
-  // Second invitation for the same email while first is pending → 409
+  // Re-inviting the same open email refreshes the invite → 201 with a new link
   const adminAgent = await signedInAdminAgent();
   const res = await adminAgent
     .post("/api/admin/invitations")
     .set("Origin", serverUrl)
     .send({ email: sharedEmail, role: "standard" })
-    .expect(409);
-  expect(res.body.error).toBeDefined();
+    .expect(201);
+  expect(res.body.status).toBe("pending");
+  expect(res.body.link).not.toBe(first.link);
+
+  const secondToken = extractToken(res.body.link);
+
+  // The old link is dead; the refreshed link works
+  await agent().get(`/api/auth/invitation/${firstToken}`).set("Origin", serverUrl).expect(410);
+  await agent().get(`/api/auth/invitation/${secondToken}`).set("Origin", serverUrl).expect(200);
 });

--- a/src/server/auth/invitationStore.test.ts
+++ b/src/server/auth/invitationStore.test.ts
@@ -86,8 +86,12 @@ async function insertTestUser(email: string): Promise<string> {
   return userId;
 }
 
-/** Insert an expired pending invitation row directly for lazy-expire tests. */
-async function insertExpiredPendingInvitation(email: string, invitedBy: string): Promise<void> {
+/**
+ * Insert an expired (past-due, never accepted/retracted) invitation row directly.
+ * Status is derived, so "expired" just means a past expiresAt with both
+ * acceptedAt and retractedAt null. Returns the row id.
+ */
+async function insertExpiredPendingInvitation(email: string, invitedBy: string): Promise<string> {
   const id = crypto.randomUUID();
   const tokenHash = crypto.randomBytes(32).toString("hex");
   const tokenEnc = "placeholder:placeholder:placeholder";
@@ -97,13 +101,14 @@ async function insertExpiredPendingInvitation(email: string, invitedBy: string):
   try {
     await client.query(
       `INSERT INTO "invitation"
-         ("id","email","role","status","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
-       VALUES ($1,$2,'standard','pending',$3,$4,$5,$6,$7)`,
+         ("id","email","role","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
+       VALUES ($1,$2,'standard',$3,$4,$5,$6,$7)`,
       [id, email.toLowerCase(), tokenHash, tokenEnc, invitedBy, now, expiredAt]
     );
   } finally {
     client.release();
   }
+  return id;
 }
 
 // ------------------------------------------------------------------
@@ -167,13 +172,15 @@ describe("createInvitation(pool, input)", () => {
   });
 
   // ------------------------------------------------------------------
-  // 3. Rejects when a pending invite already exists for that email (FR-005)
+  // 3. Re-inviting an open email REFRESHES the invite in place (FR-005, #115):
+  //    new token + new expiry, old link dies, refreshed role; still one row.
   // ------------------------------------------------------------------
 
-  it("rejects with 'active pending invite' error when pending invite already exists (FR-005)", async () => {
+  it("refreshes the open invite on re-invite: new link, old link dead, single row (FR-005)", async () => {
     const email = "pending-invite@example.com";
-    // Create the first invitation (should succeed)
-    await createInvitation(pool, {
+
+    // First invitation
+    const first = await createInvitation(pool, {
       email,
       role: "standard",
       invitedBy,
@@ -181,16 +188,38 @@ describe("createInvitation(pool, input)", () => {
       cookieSecret,
     });
 
-    // Second invitation for same email must fail
-    await expect(
-      createInvitation(pool, {
-        email,
-        role: "admin",
-        invitedBy,
-        baseUrl,
-        cookieSecret,
-      })
-    ).rejects.toMatchObject({ code: "PENDING_INVITE_EXISTS" });
+    // Re-inviting the same open email succeeds and refreshes the invite
+    const second = await createInvitation(pool, {
+      email,
+      role: "admin",
+      invitedBy,
+      baseUrl,
+      cookieSecret,
+    });
+
+    expect(second.status).toBe("pending");
+    expect(second.role).toBe("admin");
+    // A fresh token was issued — the link (and its tokenHash) changed
+    expect(second.link).not.toBe(first.link);
+    expect(second.tokenHash).not.toBe(first.tokenHash);
+
+    // The old link no longer looks up; the new one does
+    const oldToken = first.link.split("/").pop()!;
+    const newToken = second.link.split("/").pop()!;
+    expect(await lookupInvitation(pool, oldToken)).toBeNull();
+    expect(await lookupInvitation(pool, newToken)).toEqual({ email: email.toLowerCase() });
+
+    // Still exactly one row for this email (refreshed in place, not duplicated)
+    const client = await pool.connect();
+    try {
+      const res = await client.query<{ count: string }>(
+        `SELECT count(*) FROM "invitation" WHERE LOWER(email) = $1`,
+        [email.toLowerCase()]
+      );
+      expect(parseInt(res.rows[0].count, 10)).toBe(1);
+    } finally {
+      client.release();
+    }
   });
 
   // ------------------------------------------------------------------
@@ -201,8 +230,8 @@ describe("createInvitation(pool, input)", () => {
     const email = "expired-prior@example.com";
     await insertExpiredPendingInvitation(email, invitedBy);
 
-    // Should succeed — the lazy-expire logic transitions the old row to 'expired'
-    // before the partial-unique-pending index check
+    // Should succeed — a past-due open row is still "open" per the partial index,
+    // so the UPSERT refreshes it in place back to a fresh pending invite.
     const result = await createInvitation(pool, {
       email,
       role: "standard",
@@ -269,18 +298,18 @@ describe("createInvitation(pool, input)", () => {
   });
 
   // ------------------------------------------------------------------
-  // 8. On tokenHash collision (23505 on idx_invitation_tokenHash), retries once
-  //    and does NOT map it to the FR-005 PENDING_INVITE_EXISTS error
+  // 8. On tokenHash collision (23505 on the tokenHash unique constraint — NOT
+  //    the open-email ON CONFLICT target), retries once with a fresh token.
   // ------------------------------------------------------------------
 
-  it("retries on tokenHash collision without surfacing PENDING_INVITE_EXISTS", async () => {
+  it("retries on tokenHash collision rather than failing the create", async () => {
     // We cannot easily force a SHA-256 collision, but we can verify that when
-    // the store detects a 23505 on idx_invitation_tokenHash it retries rather
-    // than erroring with PENDING_INVITE_EXISTS.
+    // the store detects a 23505 on the tokenHash unique constraint it retries
+    // (the UPSERT's ON CONFLICT only absorbs the open-email index; a tokenHash
+    // collision against ANOTHER row still surfaces as an error to be retried).
     //
     // Strategy: spy on generateToken to return a colliding hash on the first call,
-    // then a unique one on the retry. This test verifies constraint-name
-    // discrimination (plan.md Pass 11).
+    // then a unique one on the retry.
     //
     // Pre-insert an invitation with a known tokenHash to force the collision.
     const collidingTokenHash = crypto.randomBytes(32).toString("hex");
@@ -291,8 +320,8 @@ describe("createInvitation(pool, input)", () => {
     try {
       await client.query(
         `INSERT INTO "invitation"
-           ("id","email","role","status","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
-         VALUES ($1,'collision-seed@example.com','standard','pending',$2,'placeholder:placeholder:placeholder',$3,$4,$5)`,
+           ("id","email","role","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
+         VALUES ($1,'collision-seed@example.com','standard',$2,'placeholder:placeholder:placeholder',$3,$4,$5)`,
         [collidingId, collidingTokenHash, invitedBy, now, expiresAt]
       );
     } finally {
@@ -329,7 +358,7 @@ describe("createInvitation(pool, input)", () => {
         baseUrl,
         cookieSecret,
       });
-      // Should succeed after retry — not throw PENDING_INVITE_EXISTS
+      // Should succeed after retry
       expect(result.email).toBe("retry-target@example.com");
       expect(result.status).toBe("pending");
     } finally {
@@ -339,28 +368,15 @@ describe("createInvitation(pool, input)", () => {
   });
 
   // ------------------------------------------------------------------
-  // 9. Lazy-expire: expired pending row transitions to 'expired' before insert
+  // 9. Re-inviting a past-due email refreshes the SAME row in place (no
+  //    duplicate, no stored-status maintenance — status is derived) (#115)
   // ------------------------------------------------------------------
 
-  it("handles lazy-expire: an expired pending row is transitioned to 'expired' before the insert", async () => {
+  it("re-inviting a past-due email refreshes the same row in place (single row, derives pending)", async () => {
     const email = "lazy-expire@example.com";
-    await insertExpiredPendingInvitation(email, invitedBy);
+    const expiredId = await insertExpiredPendingInvitation(email, invitedBy);
 
-    // Verify the old row is in the 'pending' state before the call
-    const clientBefore = await pool.connect();
-    let rowBefore;
-    try {
-      const res = await clientBefore.query(
-        `SELECT status FROM "invitation" WHERE LOWER(email) = $1`,
-        [email.toLowerCase()]
-      );
-      rowBefore = res.rows[0];
-    } finally {
-      clientBefore.release();
-    }
-    expect(rowBefore?.status).toBe("pending");
-
-    // createInvitation should succeed (lazy-expire fires first)
+    // createInvitation should succeed by refreshing the past-due open row
     const result = await createInvitation(pool, {
       email,
       role: "standard",
@@ -369,21 +385,24 @@ describe("createInvitation(pool, input)", () => {
       cookieSecret,
     });
     expect(result.status).toBe("pending");
+    // The refreshed row keeps the same id (UPSERT updated in place)
+    expect(result.id).toBe(expiredId);
 
-    // Verify the old row was transitioned to 'expired'
+    // Exactly one row exists, and its derived status is now pending
     const clientAfter = await pool.connect();
     try {
-      const res = await clientAfter.query(
-        `SELECT status FROM "invitation" WHERE LOWER(email) = $1 ORDER BY "createdAt" ASC`,
+      const res = await clientAfter.query<{ count: string }>(
+        `SELECT count(*) FROM "invitation" WHERE LOWER(email) = $1`,
         [email.toLowerCase()]
       );
-      // Two rows: the expired one (first, by createdAt) and the new pending one
-      expect(res.rows.length).toBe(2);
-      expect(res.rows[0].status).toBe("expired");
-      expect(res.rows[1].status).toBe("pending");
+      expect(parseInt(res.rows[0].count, 10)).toBe(1);
     } finally {
       clientAfter.release();
     }
+
+    const list = await listInvitations(pool);
+    const found = list.find((inv) => inv.email === email.toLowerCase());
+    expect(found?.status).toBe("pending");
   });
 });
 
@@ -448,7 +467,7 @@ describe("lookupInvitation(pool, token)", () => {
     const client = await pool.connect();
     try {
       await client.query(
-        `UPDATE "invitation" SET status='accepted', "acceptedAt"=now() WHERE "id"=$1`,
+        `UPDATE "invitation" SET "acceptedAt"=now() WHERE "id"=$1`,
         [created.id]
       );
     } finally {
@@ -477,7 +496,7 @@ describe("lookupInvitation(pool, token)", () => {
     // Retract the invitation directly
     const client = await pool.connect();
     try {
-      await client.query(`UPDATE "invitation" SET status='retracted' WHERE "id"=$1`, [created.id]);
+      await client.query(`UPDATE "invitation" SET "retractedAt"=now() WHERE "id"=$1`, [created.id]);
     } finally {
       client.release();
     }
@@ -584,7 +603,15 @@ describe("acceptInvitation(pool, token, password, name)", () => {
     const client = await pool.connect();
     try {
       const res = await client.query<{ status: string; acceptedAt: Date | null }>(
-        `SELECT status, "acceptedAt" FROM "invitation" WHERE id=$1 LIMIT 1`,
+        `SELECT
+           CASE
+             WHEN "retractedAt" IS NOT NULL THEN 'retracted'
+             WHEN "acceptedAt"  IS NOT NULL THEN 'accepted'
+             WHEN "expiresAt"   <= now()    THEN 'expired'
+             ELSE 'pending'
+           END AS status,
+           "acceptedAt"
+         FROM "invitation" WHERE id=$1 LIMIT 1`,
         [id]
       );
       return res.rows[0] ?? null;
@@ -740,7 +767,7 @@ describe("acceptInvitation(pool, token, password, name)", () => {
     // Retract the invitation (simulating admin retraction while form was open)
     const client = await pool.connect();
     try {
-      await client.query(`UPDATE "invitation" SET status='retracted' WHERE "id"=$1`, [created.id]);
+      await client.query(`UPDATE "invitation" SET "retractedAt"=now() WHERE "id"=$1`, [created.id]);
     } finally {
       client.release();
     }
@@ -1077,10 +1104,10 @@ describe("listInvitations(pool)", () => {
   });
 
   // ------------------------------------------------------------------
-  // 5. Lazy-expire: pending row with past expiresAt appears as 'expired'
+  // 5. Derived status: a past-due row appears as 'expired' (no sweep needed)
   // ------------------------------------------------------------------
 
-  it("lazy-expire: a pending row with past expiresAt appears as status 'expired'", async () => {
+  it("derives 'expired' for a row with a past expiresAt (no stored status)", async () => {
     const email = "list-lazy-expire@example.com";
     await insertExpiredPendingInvitation(email, invitedBy);
 
@@ -1118,7 +1145,7 @@ describe("listInvitations(pool)", () => {
     const client = await pool.connect();
     try {
       await client.query(
-        `UPDATE "invitation" SET status='accepted', "acceptedAt"=now() WHERE id=$1`,
+        `UPDATE "invitation" SET "acceptedAt"=now() WHERE id=$1`,
         [accepted.id]
       );
     } finally {
@@ -1206,7 +1233,7 @@ describe("retractInvitation(pool, id)", () => {
     const client = await pool.connect();
     try {
       await client.query(
-        `UPDATE "invitation" SET status='accepted', "acceptedAt"=now() WHERE id=$1`,
+        `UPDATE "invitation" SET "acceptedAt"=now() WHERE id=$1`,
         [created.id]
       );
     } finally {
@@ -1260,7 +1287,8 @@ describe("retractInvitation(pool, id)", () => {
     const client = await pool.connect();
     try {
       await client.query(
-        `UPDATE "invitation" SET status='accepted', "acceptedAt"=now() WHERE id=$1 AND status='pending'`,
+        `UPDATE "invitation" SET "acceptedAt"=now()
+         WHERE id=$1 AND "acceptedAt" IS NULL AND "retractedAt" IS NULL AND "expiresAt" > now()`,
         [created.id]
       );
     } finally {
@@ -1275,11 +1303,13 @@ describe("retractInvitation(pool, id)", () => {
     // Confirm the row is still 'accepted' — not overwritten to 'retracted'
     const verifyClient = await pool.connect();
     try {
-      const res = await verifyClient.query<{ status: string }>(
-        `SELECT status FROM "invitation" WHERE id=$1`,
+      const res = await verifyClient.query<{ acceptedAt: Date | null; retractedAt: Date | null }>(
+        `SELECT "acceptedAt", "retractedAt" FROM "invitation" WHERE id=$1`,
         [created.id]
       );
-      expect(res.rows[0].status).toBe("accepted");
+      // Still accepted (acceptedAt set), not overwritten to retracted (retractedAt null)
+      expect(res.rows[0].acceptedAt).not.toBeNull();
+      expect(res.rows[0].retractedAt).toBeNull();
     } finally {
       verifyClient.release();
     }
@@ -1348,7 +1378,7 @@ describe("getInvitationLink(pool, id, cookieSecret)", () => {
     const client = await pool.connect();
     try {
       await client.query(
-        `UPDATE "invitation" SET status='accepted', "acceptedAt"=now() WHERE id=$1`,
+        `UPDATE "invitation" SET "acceptedAt"=now() WHERE id=$1`,
         [created.id]
       );
     } finally {
@@ -1378,6 +1408,104 @@ describe("getInvitationLink(pool, id, cookieSecret)", () => {
     const wrongSecret = "this-is-a-wrong-secret-32-chars!!";
     await expect(getInvitationLink(pool, created.id, baseUrl, wrongSecret)).rejects.toMatchObject({
       code: "DECRYPT_ERROR",
+    });
+  });
+});
+
+// ------------------------------------------------------------------
+// Derived-status rule (STATUS_CASE_SQL) — precedence and each branch (#115)
+//
+// Status is no longer stored; it is derived from (retractedAt, acceptedAt,
+// expiresAt). We seed rows with each timestamp combination and read the derived
+// status back through listInvitations(), which uses the same CASE fragment.
+// Precedence: retracted > accepted > expired > pending.
+// ------------------------------------------------------------------
+
+describe("derived status (STATUS_CASE_SQL precedence)", () => {
+  let invitedBy: string;
+
+  beforeAll(async () => {
+    invitedBy = await getAdminUserId();
+  });
+
+  const future = () => new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+  const past = () => new Date(Date.now() - 1000);
+
+  /** Seed an invitation row with explicit timestamps; returns its id + email. */
+  async function seedRow(opts: {
+    label: string;
+    expiresAt: Date;
+    acceptedAt?: Date | null;
+    retractedAt?: Date | null;
+  }): Promise<{ id: string; email: string }> {
+    const id = crypto.randomUUID();
+    const email = `derived-${opts.label}@example.com`;
+    const tokenHash = crypto.randomBytes(32).toString("hex");
+    const client = await pool.connect();
+    try {
+      await client.query(
+        `INSERT INTO "invitation"
+           ("id","email","role","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt","acceptedAt","retractedAt")
+         VALUES ($1,$2,'standard',$3,'placeholder:placeholder:placeholder',$4,now(),$5,$6,$7)`,
+        [
+          id,
+          email,
+          tokenHash,
+          invitedBy,
+          opts.expiresAt,
+          opts.acceptedAt ?? null,
+          opts.retractedAt ?? null,
+        ]
+      );
+    } finally {
+      client.release();
+    }
+    return { id, email };
+  }
+
+  it("derives each status and applies retracted > accepted > expired > pending precedence", async () => {
+    const cases: Array<{
+      label: string;
+      expiresAt: Date;
+      acceptedAt?: Date | null;
+      retractedAt?: Date | null;
+      expected: string;
+    }> = [
+      // Single-condition rows
+      { label: "pending", expiresAt: future(), expected: "pending" },
+      { label: "expired", expiresAt: past(), expected: "expired" },
+      { label: "accepted", expiresAt: future(), acceptedAt: new Date(), expected: "accepted" },
+      { label: "retracted", expiresAt: future(), retractedAt: new Date(), expected: "retracted" },
+      // Precedence rows
+      {
+        label: "accepted-beats-expired",
+        expiresAt: past(),
+        acceptedAt: new Date(),
+        expected: "accepted",
+      },
+      {
+        label: "retracted-beats-accepted",
+        expiresAt: future(),
+        acceptedAt: new Date(),
+        retractedAt: new Date(),
+        expected: "retracted",
+      },
+      {
+        label: "retracted-beats-all",
+        expiresAt: past(),
+        acceptedAt: new Date(),
+        retractedAt: new Date(),
+        expected: "retracted",
+      },
+    ];
+
+    const seeded = await Promise.all(cases.map((c) => seedRow(c)));
+
+    const list = await listInvitations(pool);
+    const byEmail = new Map(list.map((inv) => [inv.email, inv.status]));
+
+    cases.forEach((c, i) => {
+      expect(byEmail.get(seeded[i].email)).toBe(c.expected);
     });
   });
 });

--- a/src/server/auth/invitationStore.ts
+++ b/src/server/auth/invitationStore.ts
@@ -19,7 +19,6 @@ import {
   validateEmail,
   validateRole,
   AccountAlreadyRegisteredError,
-  ActivePendingError,
   InvalidLinkError,
   ValidationError,
   AccountCreatedConcurrentlyError,
@@ -31,7 +30,6 @@ import {
 export type { InvitationRole, InvitationStatus } from "./invitationValidation";
 export {
   AccountAlreadyRegisteredError,
-  ActivePendingError,
   InvalidLinkError,
   ValidationError,
   AccountCreatedConcurrentlyError,
@@ -39,6 +37,26 @@ export {
   NotPendingError,
   DecryptError,
 } from "./invitationValidation";
+
+// ---------------------------------------------------------------------------
+// Derived-status rule (single definition — #115)
+// ---------------------------------------------------------------------------
+
+/**
+ * SQL CASE fragment that DERIVES the invitation status from its timestamps,
+ * replacing the old denormalized `status` column. Reused verbatim in every
+ * status-returning SELECT. Precedence: retracted > accepted > expired > pending.
+ *
+ * The referenced columns ("retractedAt", "acceptedAt", "expiresAt") exist only
+ * on "invitation", never on "user", so this stays unambiguous in the JOIN
+ * queries — no table qualification needed.
+ */
+const STATUS_CASE_SQL = `CASE
+        WHEN "retractedAt" IS NOT NULL THEN 'retracted'
+        WHEN "acceptedAt"  IS NOT NULL THEN 'accepted'
+        WHEN "expiresAt"   <= now()    THEN 'expired'
+        ELSE 'pending'
+      END`;
 
 export interface CreateInvitationInput {
   email: string;
@@ -74,18 +92,20 @@ export interface InvitationSummary {
 // ---------------------------------------------------------------------------
 
 /**
- * Creates a new pending invitation in the database.
+ * Creates (or refreshes) an open invitation for an email.
+ *
+ * Refresh-on-reinvite (#115): re-inviting an email that already has an open
+ * (pending or past-due-unswept) invite refreshes that row's token, expiry,
+ * role, and invitedBy in place via UPSERT. The old link dies; the row stays a
+ * single open invite per email (FR-005). There is no ActivePendingError.
  *
  * Steps:
  * 1. Validate email (length, format) and role
- * 2. Lazy-expire: flip any expired pending rows for this email to 'expired'
- * 3. Check for existing user account (-> AccountAlreadyRegisteredError)
- * 4. Generate token, hash, and encrypt it
- * 5. INSERT invitation row
- * 6. On pg 23505: branch on constraint name
- *    - uq_invitation_one_pending_email -> ActivePendingError
- *    - idx_invitation_tokenHash -> retry once with new token
- *    - other -> rethrow
+ * 2. Check for existing user account (-> AccountAlreadyRegisteredError)
+ * 3. Generate token, hash, and encrypt it
+ * 4. UPSERT invitation row (ON CONFLICT on the open-email partial index)
+ * 5. On pg 23505 from a tokenHash collision (NOT the ON CONFLICT target):
+ *    retry once with a fresh token; a second collision surfaces as a generic error
  */
 export async function createInvitation(
   pool: Pool,
@@ -101,22 +121,7 @@ export async function createInvitation(
 
   const client = await pool.connect();
   try {
-    // 2. Lazy-expire (scoped to THIS email). The stored `status` is
-    //    denormalized and expiry is lazy (no background job), so a past-due
-    //    invite can still sit in 'pending'. The partial unique index
-    //    uq_invitation_one_pending_email (WHERE status='pending') would make
-    //    the INSERT below collide with that stale row -> a false
-    //    ActivePendingError. Flip this email's past-due pending row(s) to
-    //    'expired' first to unblock the INSERT. Intentionally scoped to this
-    //    email, not a global sweep -- at create time we only care about this
-    //    address. (Derived-status refactor removes this; see #115.)
-    await client.query(
-      `UPDATE "invitation" SET status='expired'
-       WHERE LOWER(email) = $1 AND status = 'pending' AND "expiresAt" <= now()`,
-      [email]
-    );
-
-    // 3. Check for existing user account
+    // 2. Check for existing user account
     const userCheck = await client.query<{ id: string }>(
       `SELECT 1 FROM "user" WHERE LOWER(email) = $1 LIMIT 1`,
       [email]
@@ -125,7 +130,7 @@ export async function createInvitation(
       throw new AccountAlreadyRegisteredError(email);
     }
 
-    // 4. Build invitation -- with one retry on tokenHash collision
+    // 3/4. Build invitation -- with one retry on tokenHash collision
     return await attemptInsert(client, {
       email,
       role,
@@ -165,19 +170,33 @@ async function attemptInsert(
   const now = new Date();
   const expiresAt = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
 
+  let row: { id: string; expiresAt: Date };
   try {
-    await client.query(
+    // UPSERT on the open-email partial index (FR-005). The ON CONFLICT inference
+    // clause MUST exactly match uq_invitation_one_open_email's predicate. When an
+    // open invite already exists for this email, DO UPDATE refreshes it in place
+    // (new token, new createdAt/expiresAt, refreshed role + invitedBy) -- the old
+    // link dies. RETURNING id is load-bearing: on the UPDATE branch the surviving
+    // row's id is the EXISTING row's id, not the generated $1.
+    const result = await client.query<{ id: string; expiresAt: Date }>(
       `INSERT INTO "invitation"
-         ("id","email","role","status","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
-       VALUES ($1,$2,$3,'pending',$4,$5,$6,$7,$8)`,
+         ("id","email","role","tokenHash","tokenEnc","invitedBy","createdAt","expiresAt")
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (LOWER("email")) WHERE "acceptedAt" IS NULL AND "retractedAt" IS NULL
+       DO UPDATE SET "role"=EXCLUDED."role", "tokenHash"=EXCLUDED."tokenHash",
+                     "tokenEnc"=EXCLUDED."tokenEnc", "invitedBy"=EXCLUDED."invitedBy",
+                     "createdAt"=EXCLUDED."createdAt", "expiresAt"=EXCLUDED."expiresAt"
+       RETURNING id, "expiresAt"`,
       [id, email, role, tokenHash, tokenEnc, invitedBy, now, expiresAt]
     );
+    row = result.rows[0];
   } catch (err: unknown) {
     if (isPgUniqueViolation(err)) {
       const constraint = getConstraintName(err);
-      if (constraint === "uq_invitation_one_pending_email") {
-        throw new ActivePendingError(email);
-      }
+      // A refreshed tokenHash colliding with ANOTHER row still raises 23505 on
+      // idx_invitation_tokenHash -- that is NOT the ON CONFLICT target (the open-
+      // email index), so it propagates here rather than being absorbed by DO
+      // UPDATE. Retry once with a fresh token.
       if (
         constraint === "idx_invitation_tokenHash" ||
         constraint === "invitation_tokenhash_key" ||
@@ -199,7 +218,8 @@ async function attemptInsert(
 
   const link = buildInvitationLink(token, baseUrl);
 
-  return { id, email, role, status: "pending", tokenHash, link, expiresAt };
+  // A freshly created or refreshed row is always pending.
+  return { id: row.id, email, role, status: "pending", tokenHash, link, expiresAt: row.expiresAt };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,13 +260,12 @@ export async function lookupInvitation(
   const client = await pool.connect();
   try {
     const result = await client.query<{
-      id: string;
       email: string;
       status: string;
-      expiresAt: Date;
-    }>(`SELECT id, email, status, "expiresAt" FROM "invitation" WHERE "tokenHash" = $1 LIMIT 1`, [
-      tokenHash,
-    ]);
+    }>(
+      `SELECT email, ${STATUS_CASE_SQL} AS status FROM "invitation" WHERE "tokenHash" = $1 LIMIT 1`,
+      [tokenHash]
+    );
 
     if (result.rows.length === 0) {
       return null;
@@ -254,11 +273,10 @@ export async function lookupInvitation(
 
     const row = result.rows[0];
 
+    // Derived status collapses the old not-pending + separate-expiry checks: a
+    // past-due row derives 'expired', a consumed/withdrawn row derives
+    // accepted/retracted -- all non-pending, all non-leaky null (FR-010, FR-018).
     if (row.status !== "pending") {
-      return null;
-    }
-
-    if (new Date(row.expiresAt) <= new Date()) {
       return null;
     }
 
@@ -297,7 +315,8 @@ function hasControlChars(str: string): boolean {
  * 2. Validate name: trim, reject empty, reject control chars, check length <= 100
  * 3. Hash token -> tokenHash; SELECT invitation row
  * 4. BEGIN transaction:
- *    a. Conditional UPDATE invitation -> status='accepted' WHERE status='pending' AND expiresAt > now()
+ *    a. Conditional UPDATE invitation -> set acceptedAt WHERE the row is still
+ *       open (acceptedAt IS NULL AND retractedAt IS NULL AND expiresAt > now())
  *    b. If 0 rows updated -> ROLLBACK -> throw InvalidLinkError
  *    c. Hash password (Argon2id)
  *    d. INSERT user row
@@ -353,11 +372,12 @@ export async function acceptInvitation(
     await client.query("BEGIN");
 
     try {
-      // 4a. Conditional UPDATE: only update if status='pending' AND expiresAt > now()
+      // 4a. Conditional UPDATE: only accept if the row is still open (derived
+      //     'pending') — not already accepted, retracted, or past expiry.
       const updateResult = await client.query<{ id: string }>(
         `UPDATE "invitation"
-         SET status = 'accepted', "acceptedAt" = now()
-         WHERE id = $1 AND status = 'pending' AND "expiresAt" > now()
+         SET "acceptedAt" = now()
+         WHERE id = $1 AND "acceptedAt" IS NULL AND "retractedAt" IS NULL AND "expiresAt" > now()
          RETURNING id`,
         [invitation.id]
       );
@@ -466,7 +486,8 @@ function mapInvitationRow(row: InvitationRow): InvitationSummary {
 
 /**
  * Lists all invitations ordered newest-first.
- * Lazy-expires any pending rows with past expiresAt before fetching.
+ * Status is derived from the row's timestamps (no stored column, no lazy-expire
+ * sweep — past-due rows simply derive 'expired').
  * Resolves invitedByEmail via JOIN to the user table.
  * Never returns tokenHash or tokenEnc.
  *
@@ -476,21 +497,12 @@ function mapInvitationRow(row: InvitationRow): InvitationSummary {
 export async function listInvitations(pool: Pool): Promise<InvitationSummary[]> {
   const client = await pool.connect();
   try {
-    // Lazy-expire: flip any pending rows with past expiresAt to 'expired'
-    // (global sweep so the admin list shows correct statuses; this
-    //  denormalized-status maintenance also goes away with the
-    //  derived-status refactor -- see #115)
-    await client.query(
-      `UPDATE "invitation" SET status='expired'
-       WHERE status='pending' AND "expiresAt" <= now()`
-    );
-
     const result = await client.query<InvitationRow>(
       `SELECT
          invitation.id,
          invitation.email,
          invitation.role,
-         invitation.status,
+         ${STATUS_CASE_SQL} AS status,
          invitation."createdAt",
          invitation."expiresAt",
          invitation."acceptedAt",
@@ -512,11 +524,13 @@ export async function listInvitations(pool: Pool): Promise<InvitationSummary[]> 
 
 /**
  * Retracts a pending invitation by id.
- * Uses a conditional UPDATE (WHERE status='pending') to prevent TOCTOU races.
- * Returns the updated InvitationSummary with invitedByEmail resolved via JOIN.
+ * Uses a conditional UPDATE (matching the derived-'pending' predicate) to
+ * prevent TOCTOU races. Returns the updated InvitationSummary with
+ * invitedByEmail resolved via JOIN.
  *
  * Throws NotFoundError if the id does not exist.
- * Throws NotPendingError if the invitation is not in pending state.
+ * Throws NotPendingError if the invitation is not in pending state
+ * (already accepted, expired, or retracted).
  *
  * Spec: specs/002-invitation-system/spec.md §FR-015
  * Data model: data-model.md §State machine (retract conditional UPDATE — plan.md Pass 11)
@@ -524,10 +538,10 @@ export async function listInvitations(pool: Pool): Promise<InvitationSummary[]> 
 export async function retractInvitation(pool: Pool, id: string): Promise<InvitationSummary> {
   const client = await pool.connect();
   try {
-    // Atomic conditional UPDATE: only retract if currently pending
+    // Atomic conditional UPDATE: only retract if currently open (derived 'pending')
     const updateResult = await client.query<{ id: string }>(
-      `UPDATE "invitation" SET status='retracted'
-       WHERE id=$1 AND status='pending'
+      `UPDATE "invitation" SET "retractedAt" = now()
+       WHERE id=$1 AND "acceptedAt" IS NULL AND "retractedAt" IS NULL AND "expiresAt" > now()
        RETURNING id`,
       [id]
     );
@@ -550,7 +564,7 @@ export async function retractInvitation(pool: Pool, id: string): Promise<Invitat
          invitation.id,
          invitation.email,
          invitation.role,
-         invitation.status,
+         ${STATUS_CASE_SQL} AS status,
          invitation."createdAt",
          invitation."expiresAt",
          invitation."acceptedAt",
@@ -595,7 +609,9 @@ export async function getInvitationLink(
       id: string;
       status: InvitationStatus;
       tokenEnc: string;
-    }>(`SELECT id, status, "tokenEnc" FROM "invitation" WHERE id=$1 LIMIT 1`, [id]);
+    }>(`SELECT id, ${STATUS_CASE_SQL} AS status, "tokenEnc" FROM "invitation" WHERE id=$1 LIMIT 1`, [
+      id,
+    ]);
 
     if (result.rows.length === 0) {
       throw new NotFoundError(id);
@@ -603,6 +619,8 @@ export async function getInvitationLink(
 
     const row = result.rows[0];
 
+    // Derived status tightens this intentionally: a past-due-but-unswept link now
+    // derives 'expired' -> NotPending, so it can no longer be re-copied (#115).
     if (row.status !== "pending") {
       throw new NotPendingError(id);
     }

--- a/src/server/auth/invitationValidation.ts
+++ b/src/server/auth/invitationValidation.ts
@@ -32,14 +32,6 @@ export class AccountAlreadyRegisteredError extends Error {
   }
 }
 
-export class ActivePendingError extends Error {
-  code = "PENDING_INVITE_EXISTS" as const;
-  constructor(email: string) {
-    super(`An active pending invitation already exists for ${email}`);
-    this.name = "ActivePendingError";
-  }
-}
-
 export class InvalidEmailError extends Error {
   code = "INVALID_EMAIL" as const;
   constructor(message: string) {

--- a/src/server/controllers/invitationController.test.ts
+++ b/src/server/controllers/invitationController.test.ts
@@ -255,9 +255,10 @@ describe("POST /api/admin/invitations", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 9. 409 — active pending invite already exists (FR-005 ActivePendingError)
+  // 9. 201 — re-inviting an open email REFRESHES it (FR-005, #115): new link,
+  //    refreshed role, old link dead. No ActivePendingError.
   // -------------------------------------------------------------------------
-  it("409: rejects when an active pending invitation already exists for this email (FR-005)", async () => {
+  it("201: re-inviting an open email refreshes it with a new link (FR-005)", async () => {
     const agent = await loggedInAgent();
     const email = `pending-conflict-${crypto.randomUUID()}@example.com`;
 
@@ -265,11 +266,22 @@ describe("POST /api/admin/invitations", () => {
     const first = await agent.post("/api/admin/invitations").send({ email, role: "standard" });
     expect(first.status).toBe(201);
 
-    // Create a second invitation for the same email — should conflict
+    // Re-invite the same open email — refreshes the invite (now with role 'admin')
     const second = await agent.post("/api/admin/invitations").send({ email, role: "admin" });
 
-    expect(second.status).toBe(409);
-    expect(second.body).toMatchObject({ error: expect.any(String), code: "PENDING_INVITE_EXISTS" });
+    expect(second.status).toBe(201);
+    expect(second.body).toMatchObject({
+      email: email.toLowerCase(),
+      role: "admin",
+      status: "pending",
+    });
+    expect(second.body.link).not.toBe(first.body.link);
+
+    // The old link no longer resolves; the refreshed one does
+    const firstToken = new URL(first.body.link).pathname.split("/").pop();
+    const secondToken = new URL(second.body.link).pathname.split("/").pop();
+    await plainAgent().get(`/api/auth/invitation/${firstToken}`).expect(410);
+    await plainAgent().get(`/api/auth/invitation/${secondToken}`).expect(200);
   });
 
   // -------------------------------------------------------------------------
@@ -928,8 +940,8 @@ describe("GET /api/admin/invitations/:id/link", () => {
     const expiresAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
 
     await authPool.query(
-      `INSERT INTO "invitation" (id, email, role, status, "tokenHash", "tokenEnc", "invitedBy", "createdAt", "expiresAt")
-       VALUES ($1, $2, 'standard', 'pending', $3, $4, $5, $6, $7)`,
+      `INSERT INTO "invitation" (id, email, role, "tokenHash", "tokenEnc", "invitedBy", "createdAt", "expiresAt")
+       VALUES ($1, $2, 'standard', $3, $4, $5, $6, $7)`,
       [invitationId, email, tokenHash, garbageTokenEnc, invitedBy, createdAt, expiresAt]
     );
 

--- a/src/server/controllers/invitationController.ts
+++ b/src/server/controllers/invitationController.ts
@@ -26,7 +26,6 @@ import {
 } from "../auth/invitationStore";
 import {
   AccountAlreadyRegisteredError,
-  ActivePendingError,
   InvalidEmailError,
   InvalidRoleError,
   ValidationError,
@@ -223,10 +222,6 @@ export default function invitationController(app: Express, pool: Pool): void {
         });
       } catch (err) {
         if (err instanceof AccountAlreadyRegisteredError) {
-          res.status(409).json({ error: err.message, code: err.code });
-          return;
-        }
-        if (err instanceof ActivePendingError) {
           res.status(409).json({ error: err.message, code: err.code });
           return;
         }


### PR DESCRIPTION
## Summary

The denormalized `status` column was the *only* reason the two lazy-expire `UPDATE`s existed (`createInvitation` email-scoped + `listInvitations` global sweep). This **derives** status from timestamps instead — a single source of truth, no drift, both lazy-expire UPDATEs gone.

Outcome: keep `expiresAt` + `acceptedAt`, **add `retractedAt`**, **drop `status`**. The four status values are unchanged in the API (computed, not stored), so the frontend contract is preserved.

Closes #115.

### Derived-status rule (single definition, `STATUS_CASE_SQL`)
```
retractedAt IS NOT NULL → 'retracted'
acceptedAt  IS NOT NULL → 'accepted'
expiresAt   <= now()    → 'expired'
else                    → 'pending'
```

## Changes
- **Migration** `1781767466147-AddInvitationRetractedAtDropStatus.js` — adds `retractedAt`, backfills retracted rows, swaps the partial unique index `uq_invitation_one_pending_email` → `uq_invitation_one_open_email` (`WHERE acceptedAt IS NULL AND retractedAt IS NULL`), drops `status`. Fully reversible `down`.
- **Store** — shared `STATUS_CASE_SQL` reused in every status-returning SELECT; conditional UPDATEs (accept/retract) use the timestamp predicate; both lazy-expire UPDATEs removed.
- **Refresh-on-reinvite** — re-inviting an open email UPSERTs on the open-email index, refreshing token/expiry/role/invitedBy in place and killing the old link (returns **201**). `ActivePendingError` / `PENDING_INVITE_EXISTS` removed across server, controller, frontend thunk, and i18n.
- **Intentional tightening** — `getInvitationLink` for a past-due link now derives `expired` → `NotPending`, so a stale link can no longer be re-copied.

## Out of scope
No API response-shape change (no `retractedAt` exposed), desktop untouched, domain `postgres` driver untouched.

## Verification
- `yarn typecheck` ✅ · `yarn lint` ✅ (0 errors)
- Unit suite ✅ **114 suites / 1196 tests** (incl. a new `STATUS_CASE_SQL` precedence test)
- Integration (compiled server) ✅ **36/36**
- Cypress e2e ✅ **30/30** (invitation spec 13/13, incl. refresh-on-reinvite)
- Migration **up → down → up** roundtrip verified on test + dev DBs

> Note: stacked PR targeting `002-invitation-system` per the repo convention — #115 will close when the chain merges to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1sYSFC91u9eA5tYMXZxFv