### PR TITLE
refactor: rename "Standard" download link to "Bilingual"

### DIFF
--- a/src/frontend/web/languages/LanguageView.tsx
+++ b/src/frontend/web/languages/LanguageView.tsx
@@ -103,7 +103,7 @@ export default function LanguageView(props: IProps) {
                     <GetDocumentButton
                       language={props.language}
                       lesson={lesson}
-                      text="Standard"
+                      text="Bilingual"
                       majorityLanguageId={
                         props.language.motherTongue
                           ? props.language.defaultSrcLang


### PR DESCRIPTION
## Summary

On the Language admin screen each lesson row shows a download control reading `Download:  Standard | Single-Language`. The word **Standard** was unclear about what the document is — it's the **bilingual** (source + mother-tongue) export, as opposed to the "Single-Language" export. This relabels it to **Bilingual** for clarity.

## Change

Single edit in `src/frontend/web/languages/LanguageView.tsx`:

```diff
- text="Standard"
+ text="Bilingual"
```

- Label-only change — the sibling `text="Single-Language"` prop stays as-is (both are hardcoded, no i18n keys involved).
- Download **behavior is untouched**: the two downloads differ only by the numeric `majorityLanguageId` query param (`> 0` = bilingual doc, `== 0` = single-language). There is no `standard` identifier, route param, filename, or type anywhere behind the button, so no machinery renaming is needed.
- The unrelated invitation-role "Standard" label (`Invitation_role_standard`) is intentionally **not** changed.

## Verification

- `yarn typecheck` passes (also runs in pre-commit).
- No test references the download-link "Standard" label, so no test needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)