### PR TITLE
refactor: extract storage instantiation into makeStorage factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "migrate:test": "TEST_DB=true node scripts/migrate.js",
     "reset:dev": "node scripts/reset-dev.js",
     "seed-dev-docs": "node scripts/seed-dev-docs.js",
+    "generate-previews": "tsc -b ./src/server && NODE_ENV=production node dist/server/tasks/generateAllWebPreviews.js",
+    "generate-previews:dev": "tsc -b ./src/server && NODE_ENV=development node dist/server/tasks/generateAllWebPreviews.js",
     "test": "NODE_ENV=test jest --watchAll --runInBand",
     "test:once": "NODE_ENV=test jest --runInBand --watchAll=false",
     "test:random": "NODE_ENV=test jest --runInBand --watchAll=false --testSequencer=./RandomSequencer.js",

--- a/src/server/serverApp.ts
+++ b/src/server/serverApp.ts
@@ -14,8 +14,9 @@ import documentsController from "./controllers/documentsController";
 import invitationController, {
   registerAnonymousInvitationRoutes,
 } from "./controllers/invitationController";
-import PGStorage, { PGTestStorage, PGDevStorage } from "./storage/PGStorage";
+import { PGTestStorage } from "./storage/PGStorage";
 import { Persistence } from "../core/interfaces/Persistence";
+import makeStorage from "./storage/makeStorage";
 import docStorage from "./storage/docStorage";
 import syncController from "./controllers/syncController";
 import { getAuth, getAuthPool } from "./auth/auth";
@@ -24,13 +25,7 @@ const PRODUCTION = process.env.NODE_ENV == "production";
 
 function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
   const app = express();
-  const storage =
-    opts.storage ??
-    (PRODUCTION
-      ? new PGStorage()
-      : process.env.NODE_ENV === "test"
-        ? new PGTestStorage()
-        : new PGDevStorage());
+  const storage = opts.storage ?? makeStorage();
 
   if (!opts.storage && !PRODUCTION && !opts.silent) {
     const cls = process.env.NODE_ENV === "test" ? "PGTestStorage" : "PGDevStorage";

--- a/src/server/storage/makeStorage.ts
+++ b/src/server/storage/makeStorage.ts
@@ -1,0 +1,10 @@
+import { Persistence } from "../../core/interfaces/Persistence";
+import PGStorage, { PGTestStorage, PGDevStorage } from "./PGStorage";
+
+export default function makeStorage(): Persistence {
+  return process.env.NODE_ENV === "production"
+    ? new PGStorage()
+    : process.env.NODE_ENV === "test"
+      ? new PGTestStorage()
+      : new PGDevStorage();
+}

--- a/src/server/tasks/generateAllWebPreviews.ts
+++ b/src/server/tasks/generateAllWebPreviews.ts
@@ -1,4 +1,4 @@
-import PGStorage from "../storage/PGStorage";
+import makeStorage from "../storage/makeStorage";
 import webifyLesson from "../actions/webifyLesson";
 
 /*
@@ -9,8 +9,11 @@ import webifyLesson from "../actions/webifyLesson";
 generateAllWebPreviews();
 
 async function generateAllWebPreviews() {
-  const storage = new PGStorage();
+  const storage = makeStorage();
   const lessons = await storage.lessons();
+  console.log(
+    `Generating web previews for ${lessons.length} lessons (NODE_ENV=${process.env.NODE_ENV})`
+  );
   for (let i = 0; i < lessons.length; ++i) {
     console.log(`Generate ${lessons[i].book} ${lessons[i].series}-${lessons[i].lesson}`);
     const lesson = await storage.lesson(lessons[i].lessonId);


### PR DESCRIPTION
## Summary
- Add `src/server/storage/makeStorage.ts` to pick `PGStorage`/`PGTestStorage`/`PGDevStorage` by `NODE_ENV`, replacing duplicated branching logic in `serverApp.ts` and `generateAllWebPreviews.ts`.
- `generateAllWebPreviews` now respects `NODE_ENV` (previously hardcoded to `PGStorage`) and logs the lesson count/env before running.
- Add `generate-previews` and `generate-previews:dev` yarn scripts.

## Test plan
- [x] Pre-commit hook (typecheck, lint, jest --findRelatedTests) passed
- [x] Manually run `yarn generate-previews:dev` against a dev DB to confirm preview generation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)