### PR TITLE
fix(test): sign out admin before logged-out password-reset UI flow

### DIFF
--- a/cypress/integration/password-reset.spec.ts
+++ b/cypress/integration/password-reset.spec.ts
@@ -158,6 +158,10 @@ describe("US1 — Full reset flow: set new password, old rejected (SC-001, SC-00
       // Clear the invitation email so only the reset email appears in the buffer
       clearSentEmails();
 
+      // The beforeEach cy.login() authenticated the shared cookie jar as admin so we could
+      // create the test user. Sign out before driving the logged-out reset UI (mirrors translate.spec.js).
+      cy.request("POST", "/api/auth/sign-out");
+
       // Step 1: Navigate to forgot-password via the sign-in page link
       cy.visit("/");
       cy.contains("a", "Forgot password?").click();
@@ -219,6 +223,10 @@ describe("US1 — Full reset flow: set new password, old rejected (SC-001, SC-00
 
     createTestUser(email, oldPassword);
     clearSentEmails();
+
+    // The beforeEach cy.login() authenticated the shared cookie jar as admin so we could
+    // create the test user. Sign out before driving the logged-out reset UI (mirrors translate.spec.js).
+    cy.request("POST", "/api/auth/sign-out");
 
     // Request reset via API (faster than UI for this subsidiary test)
     cy.request("POST", "/api/auth/request-password-reset", { email });

--- a/scripts/shuffle-cypress-specs.js
+++ b/scripts/shuffle-cypress-specs.js
@@ -4,9 +4,14 @@ const path = require("path");
 
 function getSpecFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true, recursive: true });
-  return entries
-    .filter((e) => e.isFile() && e.name.endsWith(".spec.js"))
-    .map((e) => path.join(e.parentPath ?? e.path, e.name));
+  return (
+    entries
+      // Match cypress.config.js specPattern ("**/*.spec.{js,ts}"). Globbing only
+      // *.spec.js silently drops TypeScript specs (e.g. password-reset.spec.ts) from
+      // the randomized CI run, so they never execute and never gate a merge.
+      .filter((e) => e.isFile() && /\.spec\.(js|ts)$/.test(e.name))
+      .map((e) => path.join(e.parentPath ?? e.path, e.name))
+  );
 }
 
 const specs = getSpecFiles("cypress/integration");


### PR DESCRIPTION
## Problem

`cypress/integration/password-reset.spec.ts` fails consistently in environments where `cy.login()` actually establishes a session: the two "Full reset flow" tests expect the **logged-out** sign-in screen (with the "Forgot password?" link and "Log In" button) but instead see a signed-in home, so those assertions time out after 10s.

### Root cause (spec bug)

The `describe("US1 — Full reset flow …")` block's `beforeEach` calls `cy.login()` so `createTestUser()` can hit the admin-only `POST /api/admin/invitations`. Because `cy.request` shares the browser cookie jar, the browser stays authenticated as **admin** for the rest of the test. Both tests then drive a logged-out UI flow, but `src/frontend/web/MainRouter.tsx` hard-gates on `<LoadingSnake />` until `loadCurrentUser()` → `authClient.getSession()` resolves, then renders `renderHome(user)`. With the admin cookie present that returns `AdminHome`, so the "Forgot password?" link / "Log In" button never render (no PublicHome-first paint → deterministic, not a race).

### Why CI and the team never caught it (runner bug)

CI's e2e job runs `scripts/run-cypress-random.sh` → `yarn cypress:run:random` → `scripts/shuffle-cypress-specs.js`, which globbed **only `*.spec.js`**. `password-reset.spec.ts` is the repo's first and only TypeScript Cypress spec, so it was silently dropped from the randomized `--spec` list and **never executed in CI** — the 005 merge went green without ever running it. Meanwhile `cypress.config.js`'s `specPattern` is `**/*.spec.{js,ts}`, so a plain `cypress run` (`yarn test-e2e`, or `--spec …/password-reset.spec.ts`) does pick it up — which is the path the reporting tester used.

## Fix

**Commit 1 — spec:** sign out via `cy.request("POST", "/api/auth/sign-out")` after the admin-only setup and before the logged-out UI flow, in both tests. Mirrors the established idiom in `cypress/integration/translate.spec.js` (login → admin API call → API sign-out → drive logged-out UI). Deliberately **not** a UI `cy.contains("Log Out").click()` workaround, which couples the tests to the home screen's Log Out control.

**Commit 2 — CI runner:** `shuffle-cypress-specs.js` now matches `*.spec.{js,ts}`, aligning it with `cypress.config.js` so `.ts` specs actually run in CI (and so this spec — and the fix above — is finally gated). Without this, the fix would remain unverified by CI.

No change to the first `describe` block ("Forgot-password navigation …"): its `beforeEach` only calls `clearSentEmails()` (no login), so it is already logged out.

## Verification

Local full green reproduction wasn't safely completable in this workspace (the shared `lessons-from-luke-test` DB's seeded admin hash matches a different checkout's `secrets.json`, and port 8080 is held by that other checkout's dev server — so I did not mutate shared state). I confirmed the failure mechanism end-to-end with the full stack up (after rebuilding `dist/server`, which predated the 005 test controller). With commit 2, CI now runs the spec, so this PR's own e2e job exercises the fix. A reviewer with a working local `adminPassword` can also confirm red→green:

\`\`\`
npx cypress run --spec cypress/integration/password-reset.spec.ts
yarn cypress:run:random   # now includes the .ts spec
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)