### PR TITLE
fix(csp): restore lesson-preview styling and click-to-select under prod CSP

### DIFF
--- a/cypress/prod/docpreview-csp-smoke.spec.js
+++ b/cypress/prod/docpreview-csp-smoke.spec.js
@@ -1,0 +1,127 @@
+import { recordCspViolations } from "../support/prod-e2e";
+
+// Production-mode smoke test for the two CSP mechanisms DocPreview relies on.
+//
+// Why this exists: DocPreview injects LibreOffice-generated HTML via
+// `dangerouslySetInnerHTML` under the Express production server's real CSP.
+// Dev (webpack-dev-server, no helmet) has no CSP, and jsdom (Jest) does not
+// enforce CSP — so neither exercises "an innerHTML-injected <style nonce> and a
+// data-attribute click, under this exact style-src/script-src policy in a real
+// browser". This harness does, against :8081 (prod server, WITH its real CSP).
+//
+// It does NOT need the real /translate route or any DB data: both fixes are
+// CSP-mechanism questions independent of the lesson content, so we reproduce
+// exactly what DocPreview does to the DOM on the already-CSP-served PublicHome
+// page. The two `it`s below map 1:1 to the plan's Part A and Part B.
+//
+// Reading the nonce the way the app does: DocPreview reads the document's
+// per-request nonce from `<meta name="csp-nonce">` (seeded at page load), which
+// matches the nonce in the CSP header. `experimentalCspAllowList: true`
+// (cypress.prod.config.js) leaves style-src/script-src fully enforced with that
+// original nonce, so this is a faithful reproduction.
+
+describe("production CSP smoke — DocPreview mechanisms", () => {
+  beforeEach(() => {
+    cy.visit("/", { onBeforeLoad: recordCspViolations });
+    // PublicHome fully up (the app is CSP-served and rendered) before we probe.
+    cy.contains("h1", "Lessons from Luke").should("be.visible");
+  });
+
+  // --- Part A -------------------------------------------------------------
+  // A <style> element that arrives inside a dangerouslySetInnerHTML blob, with
+  // the document nonce stamped onto it, is honored by `style-src 'self'
+  // 'nonce-…'`. The flagged risk: does a nonce survive innerHTML fragment
+  // parsing and get applied? Prove it does — and, as an enforcement tripwire,
+  // that the SAME injection WITHOUT the nonce is blocked.
+  it("honors an innerHTML-injected <style nonce> and blocks the un-nonced one", () => {
+    // Do all DOM work in one callback and return only primitive results, so we
+    // never mix cy commands with a synchronous return in the same `.then`.
+    cy.window()
+      .then((win) => {
+        const nonce = win.document.querySelector('meta[name="csp-nonce"]')?.getAttribute("content");
+
+        // Nonced <style>, injected via innerHTML exactly like DocPreview does.
+        const nonced = win.document.createElement("div");
+        nonced.innerHTML = `<style nonce="${nonce}">.dp-nonced-probe{orphans:2}</style>`;
+        win.document.body.appendChild(nonced);
+
+        // Same injection, no nonce — must be refused by the policy.
+        const unNonced = win.document.createElement("div");
+        unNonced.innerHTML = `<style>.dp-unnonced-probe{orphans:2}</style>`;
+        win.document.body.appendChild(unNonced);
+
+        const noncedSheet = nonced.querySelector("style").sheet;
+        return {
+          // In prod the meta must exist; without it DocPreview's stamp is a
+          // no-op and the whole fix is moot.
+          hasNonce: typeof nonce === "string" && nonce.length > 0,
+          // The nonced style APPLIED: the fragment-parsed nonce was honored.
+          noncedApplied: noncedSheet !== null,
+          noncedRuleCount: noncedSheet ? noncedSheet.cssRules.length : 0,
+          // Tripwire: the un-nonced style was BLOCKED (no stylesheet). If CSP
+          // were silently not enforced, this would be a live sheet.
+          unNoncedBlocked: unNonced.querySelector("style").sheet === null,
+        };
+      })
+      .then((r) => {
+        cy.wrap(r.hasNonce, { log: false }).should("equal", true);
+        cy.wrap(r.noncedApplied, { log: false }).should("equal", true);
+        cy.wrap(r.noncedRuleCount, { log: false }).should("be.greaterThan", 0);
+        cy.wrap(r.unNoncedBlocked, { log: false }).should("equal", true);
+      });
+
+    // The blocked un-nonced style fires a style-src violation; the nonced one
+    // must NOT. Asserting exactly-one style-src violation proves both the
+    // listener is live and the nonce genuinely made the difference.
+    cy.window()
+      .its("__csp")
+      .should("satisfy", (v) => v.filter((s) => /style-src/.test(s)).length === 1);
+  });
+
+  // --- Part B -------------------------------------------------------------
+  // The clickable strings no longer use an inline `onclick=` attribute (blocked
+  // by `script-src 'self'`); they carry a data attribute and rely on a
+  // JS-registered (delegated) listener, which script-src does not block. Prove
+  // the old inline handler is dead under this CSP and the new delegation works.
+  it("blocks an inline onclick but runs a delegated listener under script-src", () => {
+    cy.window()
+      .then((win) => {
+        win.__inlineRan = false;
+        win.__delegatedIndex = null;
+
+        // OLD approach: inline onclick attribute, injected via innerHTML. Under
+        // `script-src 'self'` (no unsafe-inline/unsafe-hashes) this handler is
+        // refused — clicking must NOT set the flag.
+        const oldSpan = win.document.createElement("div");
+        oldSpan.innerHTML = `<span id="dp-inline" onclick="window.__inlineRan = true">x</span>`;
+        win.document.body.appendChild(oldSpan);
+
+        // NEW approach: data-ls-index + a delegated listener on the container
+        // (mirrors React's synthetic onClick — a JS-added listener, never
+        // blocked by script-src).
+        const container = win.document.createElement("div");
+        container.innerHTML = `<span class="lessonString" data-ls-index="3">y</span>`;
+        container.addEventListener("click", (e) => {
+          const el = e.target.closest(".lessonString");
+          if (el && el.dataset.lsIndex !== undefined) {
+            win.__delegatedIndex = Number(el.dataset.lsIndex);
+          }
+        });
+        win.document.body.appendChild(container);
+
+        win.document.getElementById("dp-inline").click();
+        container.querySelector(".lessonString").click();
+      })
+      .then(() => {
+        cy.window().its("__inlineRan").should("equal", false);
+        cy.window().its("__delegatedIndex").should("equal", 3);
+      });
+
+    // The blocked inline handler fires a script-src(-attr) violation, proving it
+    // was genuinely refused (not merely a no-op). The delegated listener fires
+    // no violation.
+    cy.window()
+      .its("__csp")
+      .should("satisfy", (v) => v.some((s) => /script-src/.test(s)));
+  });
+});

--- a/src/frontend/common/translate/DocPreview.test.tsx
+++ b/src/frontend/common/translate/DocPreview.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import DocPreview from "./DocPreview";
+import { LessonTString } from "./useLessonTStrings";
+import { sampleLessonString, sampleTString } from "../testHelpers";
+
+// jsdom does not enforce CSP, so these assert the structure and behavior the CSP
+// fixes depend on (data-attribute delegation, nonce stamping), not CSP itself.
+
+function ltString(lessonStringId: number, text: string): LessonTString {
+  return {
+    lStr: { ...sampleLessonString, lessonStringId },
+    tStrs: [{ ...sampleTString, text }],
+  };
+}
+
+function renderPreview(overrides: Partial<React.ComponentProps<typeof DocPreview>> = {}) {
+  const props: React.ComponentProps<typeof DocPreview> = {
+    lessonId: 5,
+    srcLangId: 1,
+    targetLangId: 42,
+    docHtml: "<p>##10##</p>",
+    ltStringsForTranslation: [ltString(10, "First string")],
+    otherLTStrings: [],
+    setSelectedIndex: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<DocPreview {...props} />) };
+}
+
+describe("DocPreview", () => {
+  afterEach(() => {
+    document.head.querySelectorAll('meta[name="csp-nonce"]').forEach((el) => el.remove());
+  });
+
+  describe("clickable lesson strings (Part B — no inline onclick)", () => {
+    it("emits spans with data-ls-index and no onclick attribute", () => {
+      const { container } = renderPreview();
+      const span = container.querySelector(".lessonString");
+      expect(span).not.toBeNull();
+      expect(span!.getAttribute("data-ls-index")).toBe("0");
+      expect(span!.getAttribute("onclick")).toBeNull();
+    });
+
+    it("calls setSelectedIndex with the clicked string's index via delegation", () => {
+      const setSelectedIndex = jest.fn();
+      const { container } = renderPreview({
+        docHtml: "<p>##10## ##11##</p>",
+        ltStringsForTranslation: [ltString(10, "First"), ltString(11, "Second")],
+        setSelectedIndex,
+      });
+
+      const spans = container.querySelectorAll(".lessonString");
+      expect(spans).toHaveLength(2);
+
+      spans[1].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(setSelectedIndex).toHaveBeenCalledWith(1);
+    });
+
+    it("ignores clicks that are not on a lesson string", () => {
+      const setSelectedIndex = jest.fn();
+      const { container } = renderPreview({ setSelectedIndex });
+      container.firstElementChild!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(setSelectedIndex).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("style nonce stamping (Part A)", () => {
+    function setNonce(value: string) {
+      const meta = document.createElement("meta");
+      meta.setAttribute("name", "csp-nonce");
+      meta.setAttribute("content", value);
+      document.head.appendChild(meta);
+    }
+
+    it("stamps the document nonce onto <style> elements when the meta is present", () => {
+      setNonce("test-nonce-123");
+      const { container } = renderPreview({
+        docHtml: "<style>p { orphans: 2; }</style><p>##10##</p>",
+      });
+      const style = container.querySelector("style");
+      expect(style).not.toBeNull();
+      expect(style!.getAttribute("nonce")).toBe("test-nonce-123");
+    });
+
+    it("leaves <style> unstamped when there is no csp-nonce meta (desktop path)", () => {
+      const { container } = renderPreview({
+        docHtml: "<style>p { orphans: 2; }</style><p>##10##</p>",
+      });
+      const style = container.querySelector("style");
+      expect(style).not.toBeNull();
+      expect(style!.getAttribute("nonce")).toBeNull();
+    });
+  });
+});

--- a/src/frontend/common/translate/DocPreview.tsx
+++ b/src/frontend/common/translate/DocPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { LessonTString } from "./useLessonTStrings";
 import styled from "styled-components";
 import Colors from "../util/Colors";
@@ -27,23 +27,31 @@ export default function DocPreview(props: IProps) {
         `##${ltStr.lStr.lessonStringId}##`,
         `<span class="lessonString" id="ls${
           ltStr.lStr.lessonStringId
-        }" style="cursor:pointer" onclick="window.setSelectedLessonString(${index})">${escapeHTML(
+        }" style="cursor:pointer" data-ls-index="${index}">${escapeHTML(
           ltStr.tStrs[1]?.text || ltStr.tStrs[0]?.text || "[...]"
         )}</span>`
       ),
     finalHtml
   );
 
-  useEffect(() => {
-    (window as any).setSelectedLessonString = (index: number) => {
-      props.setSelectedIndex(index);
-    };
-    return () => {
-      (window as any).setSelectedLessonString = () => {};
-    };
-  });
+  // Stamp the document's CSP nonce onto every LibreOffice <style> element so the
+  // production CSP (style-src 'self' 'nonce-…') honors it. On desktop there is no
+  // csp-nonce meta and no CSP, so cspNonce is falsy and we leave the HTML untouched.
+  const cspNonce = document.querySelector('meta[name="csp-nonce"]')?.getAttribute("content");
+  if (cspNonce) {
+    finalHtml = finalHtml.replace(/<style(?=[\s>])/gi, `<style nonce="${cspNonce}"`);
+  }
 
-  return <PreviewDiv dangerouslySetInnerHTML={{ __html: finalHtml }} />;
+  const handlePreviewClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const el = (e.target as HTMLElement).closest(".lessonString");
+    if (el instanceof HTMLElement && el.dataset.lsIndex !== undefined) {
+      props.setSelectedIndex(Number(el.dataset.lsIndex));
+    }
+  };
+
+  return (
+    <PreviewDiv onClick={handlePreviewClick} dangerouslySetInnerHTML={{ __html: finalHtml }} />
+  );
 }
 
 const PreviewDiv = styled.div<React.HTMLAttributes<HTMLDivElement>>`

--- a/src/server/serverApp.test.ts
+++ b/src/server/serverApp.test.ts
@@ -51,6 +51,21 @@ describe("HTTP security headers", () => {
     expect(styleSrcValue).not.toContain("'unsafe-inline'");
   });
 
+  test("Content-Security-Policy allows inline style ATTRIBUTES via style-src-attr", async () => {
+    // The lesson preview injects LibreOffice-generated HTML whose formatting
+    // (verse highlights, header bar, table borders/fills) lives in inline
+    // style="…" attributes. CSP nonces cannot cover style attributes, so this
+    // 'unsafe-inline' is required for the preview to render in production —
+    // removing it silently strips all preview styling. It is deliberately
+    // scoped to style-src-attr; style-src (i.e. <style> elements) stays
+    // nonce-controlled per the test above.
+    const app = serverApp({ silent: true });
+    const response = await request(app).get("/api/languages");
+    const csp = (response.header["content-security-policy"] ?? "") as string;
+    const styleSrcAttr = csp.match(/style-src-attr\s+([^;]*)/i)?.[1] ?? "";
+    expect(styleSrcAttr).toContain("'unsafe-inline'");
+  });
+
   test("Content-Security-Policy styleSrc carries a per-request nonce", async () => {
     // styled-components injects runtime <style> tags; without a style-src nonce
     // (and with no 'unsafe-inline') the production SPA throws

--- a/src/server/serverApp.ts
+++ b/src/server/serverApp.ts
@@ -92,11 +92,27 @@ function serverApp(opts: { silent?: boolean; storage?: Persistence } = {}) {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'"],
           // Allow styled-components' runtime <style> tags via a per-request
-          // nonce instead of the blanket 'unsafe-inline'.
+          // nonce instead of the blanket 'unsafe-inline'. This governs <style>
+          // ELEMENTS (style-src-elem falls back to style-src).
           styleSrc: [
             "'self'",
             (_req, res) => `'nonce-${(res as express.Response).locals.cspNonce}'`,
           ],
+          // The lesson preview injects LibreOffice-generated HTML (DocPreview.tsx,
+          // via dangerouslySetInnerHTML) whose formatting — verse highlights, the
+          // header bar, table borders/fills — lives in inline style="…" attributes.
+          // CSP nonces cannot cover style ATTRIBUTES (only <style>/<script>
+          // elements), so 'unsafe-inline' is the only way to let them render.
+          // Scoped to attributes only: <style> elements stay nonce-controlled
+          // above. This does open attribute-based CSS vectors (UI-redressing,
+          // attribute-selector data exfil) app-wide, but script-src is untouched,
+          // so the script-execution surface is unchanged.
+          // NOTE: style-src-attr is a CSP3 directive supported by all modern
+          // browsers (Chrome 75+, Firefox 108+, Safari 15.4+). Browsers older
+          // than that ignore it and fall back to style-src, which re-blocks the
+          // inline attributes — i.e. they degrade to the same unstyled preview
+          // they already get today, so no one regresses.
+          styleSrcAttr: ["'unsafe-inline'"],
           imgSrc: ["'self'", "data:", "blob:"],
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],


### PR DESCRIPTION
## Context

Production's strict CSP (helmet, `src/server/serverApp.ts`) broke three things in the `/translate`
lesson preview, which injects LibreOffice-generated HTML via `dangerouslySetInnerHTML` in
`DocPreview.tsx`. Dev (webpack-dev-server, no CSP) hides all three, so they only surfaced in prod.

## Changes

1. **Inline `style="…"` attributes** (verse highlights, header bar, borders) — blocked by `style-src`.
   Fixed with `styleSrcAttr: ['unsafe-inline']` (server, `serverApp.ts`).
2. **Part A — the LibreOffice `<head><style>` block** (Andika font + paragraph spacing) — a `<style>`
   *element* with no nonce, blocked under `style-src 'self' 'nonce-…'`. Now stamped client-side with the
   document's `csp-nonce` (read the same way as `webApp.tsx`). Null-safe on desktop (no meta, no CSP).
3. **Part B — click-to-select was dead in prod.** The clickable spans used an inline
   `onclick="window.setSelectedLessonString(i)"` handler, blocked by `script-src`. Replaced with a
   `data-ls-index` attribute + React `onClick` event delegation. Removes the `window.*` global bridge —
   cleaner and *more* secure (no `script-src` loosening).

Parts A and B are client-side only, both in `DocPreview.tsx`. No server/CSP change beyond the
`styleSrcAttr` (nonces can't cover inline style *attributes*).

## Tests

- `DocPreview.test.tsx` (jsdom): delegation fires `setSelectedIndex` with the right index; spans carry
  `data-ls-index` and no `onclick`; `<style>` gets a nonce when the meta is present and none when absent
  (desktop path).
- `cypress/prod/docpreview-csp-smoke.spec.js` — **prod-CSP smoke** (see below).
- Existing `serverApp.test.ts` CSP suite (15 tests) unaffected and green.

## Verified end-to-end under the real production CSP ✅

The one risk jsdom can't cover — *does a `dangerouslySetInnerHTML`-injected `<style nonce>` get honored?* —
is now confirmed against the Express prod server with its real CSP enforced (`experimentalCspAllowList: true`,
via the `e2e-prod` harness). All 3 prod specs pass:

- **Part A:** a nonce-stamped `<style>` injected via innerHTML gets a **live stylesheet**; the same
  injection **without** the nonce is **blocked** (`.sheet === null`) and fires exactly one `style-src`
  violation. The fragment-parsed nonce survives and applies.
- **Part B:** an inline `onclick=` attribute is **refused** by `script-src 'self'` (handler never runs,
  violation fires), while the JS-registered delegated listener reading `data-ls-index` **runs**.
- Regression: the existing styled-components `csp-smoke` stays green.

No fallback (post-render DOM recreation) needed — the nonce path works as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)